### PR TITLE
fix: APPS-2842 grid layout causing space at top of layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,8 +79,9 @@ dist
 .serverless
 
 # IDE
+.vscode/*
+!.vscode/extensions.json
 .idea
-
 
 # Service worker
 sw.*

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -145,16 +145,18 @@ const parsedFTVAEventScreeningDetails = computed(() => {
       <!-- sidebar slots in here on mobile -->
       <!-- on desktop sidebar is stickied to the side with css -->
       <div class="sidebar-column">
-        <BlockEventDetail
-          :start-date="page.startDateWithTime"
-          :time="page.startDateWithTime"
-          :locations="page.location"
-        />
+        <div class="sidebar-content-wrapper">
+          <BlockEventDetail
+            :start-date="page.startDateWithTime"
+            :time="page.startDateWithTime"
+            :locations="page.location"
+          />
 
-        <BlockInfo
-          v-if="page.ftvaTicketInformation && page.ftvaTicketInformation.length > 0"
-          :ftva-ticket-information="page.ftvaTicketInformation"
-        />
+          <BlockInfo
+            v-if="page.ftvaTicketInformation && page.ftvaTicketInformation.length > 0"
+            :ftva-ticket-information="page.ftvaTicketInformation"
+          />
+        </div>
       </div>
 
       <div class="primary-column bottom">
@@ -257,13 +259,18 @@ $pale-blue: #E7EDF2;
     .sidebar-column {
       min-width: 280px;
       width: 30%;
-      position: sticky;
-      align-self: start;
-      margin-left: auto;
+      position: absolute;
+      height: 100%;
       top: 0;
-      will-change: top;
+      right: 0;
       padding-top: var(--space-2xl);
       padding-bottom: 20px;
+
+      .sidebar-content-wrapper {
+        position: sticky;
+        top: 0;
+        will-change: top;
+      }
     }
   }
 

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -13,6 +13,7 @@ import FTVAEventDetail from '../gql/queries/FTVAEventDetail.gql'
 const { $graphql } = useNuxtApp()
 
 const route = useRoute()
+const globalStore = useGlobalStore()
 
 // DATA
 const { data, error } = await useAsyncData(`events-detail-${route.params.slug}`, async () => {
@@ -90,6 +91,20 @@ const parsedFTVAEventScreeningDetails = computed(() => {
     }
   })
 })
+
+// LAYOUT FUNCTIONS
+// determine if mobile
+const isMobile = computed(() => {
+  return globalStore.winWidth <= 750 // 750px is the breakpoint for {$small}
+})
+// get the height of the sidebar content
+// & set padding to match mobile or desktop layout
+const sidebar = ref(0)
+const sidebarStyles = computed(() => {
+  return {
+    paddingBottom: isMobile.value ? '0px' : `calc(${sidebar.value?.clientHeight}px + 30px)`
+  }
+})
 </script>
 
 <template>
@@ -143,17 +158,26 @@ const parsedFTVAEventScreeningDetails = computed(() => {
       </div>
 
       <!-- sidebar slots in here on mobile -->
-      <div class="sidebar-column">
-        <BlockEventDetail
-          :start-date="page.startDateWithTime"
-          :time="page.startDateWithTime"
-          :locations="page.location"
-        />
+      <!-- on desktop sidebar is stickied to the side with css -->
+      <div
+        class="sidebar-column"
+        :style="sidebarStyles"
+      >
+        <div
+          ref="sidebar"
+          class="sidebar-content-wrapper"
+        >
+          <BlockEventDetail
+            :start-date="page.startDateWithTime"
+            :time="page.startDateWithTime"
+            :locations="page.location"
+          />
 
-        <BlockInfo
-          v-if="page.ftvaTicketInformation && page.ftvaTicketInformation.length > 0"
-          :ftva-ticket-information="page.ftvaTicketInformation"
-        />
+          <BlockInfo
+            v-if="page.ftvaTicketInformation && page.ftvaTicketInformation.length > 0"
+            :ftva-ticket-information="page.ftvaTicketInformation"
+          />
+        </div>
       </div>
 
       <div class="primary-column bottom">

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -193,7 +193,7 @@ const sidebarStyles = computed(() => {
         </SectionWrapper>
       </div>
     </div>
-    <div class="full-width bottom">
+    <div class="full-width">
       <SectionWrapper
         v-if="series && series.length > 0"
         section-title="Explore upcoming events in this series"
@@ -296,11 +296,6 @@ $pale-blue: #E7EDF2;
 
     .section-wrapper.theme-paleblue {
       background-color: $pale-blue;
-    }
-
-    &.bottom {
-      position: relative;
-      z-index: 5; // ensure sticky sidebar scrolls behind this section
     }
   }
 

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -13,7 +13,6 @@ import FTVAEventDetail from '../gql/queries/FTVAEventDetail.gql'
 const { $graphql } = useNuxtApp()
 
 const route = useRoute()
-const globalStore = useGlobalStore()
 
 // DATA
 const { data, error } = await useAsyncData(`events-detail-${route.params.slug}`, async () => {

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -169,8 +169,7 @@ const parsedFTVAEventScreeningDetails = computed(() => {
         </SectionWrapper>
       </div>
     </div>
-
-    <div class="full-width">
+    <div class="full-width bottom">
       <SectionWrapper
         v-if="series && series.length > 0"
         section-title="Explore upcoming events in this series"
@@ -185,10 +184,7 @@ const parsedFTVAEventScreeningDetails = computed(() => {
   </main>
 </template>
 
-<style
-  lang="scss"
-  scoped
->
+<style lang="scss" scoped>
 // VARS - TO DO move to global? reference tokens?
 // WIDTH, HEIGHT, SPACING
 $max-width: 928px;
@@ -253,7 +249,7 @@ $pale-blue: #E7EDF2;
 
     .sidebar-column {
       grid-column: 2;
-      max-height: 25px; // when sidebar is to the side, shrink so that it does not create space in primary column
+      height: 50px; // when sidebar is to the side, shrink so that it does not create space in primary column
       position: sticky;
       align-self: start;
       top: 0;
@@ -270,6 +266,11 @@ $pale-blue: #E7EDF2;
 
     .section-wrapper.theme-paleblue {
       background-color: $pale-blue;
+    }
+
+    &.bottom {
+      position: relative;
+      z-index: 5; // ensure sticky sidebar scrolls behind this section
     }
   }
 
@@ -297,7 +298,7 @@ $pale-blue: #E7EDF2;
         grid-column: 1;
         margin: auto var(--unit-gutter);
         padding-top: 0px;
-        max-height: auto; // when sidebar is in the flow of content, content determines height
+        height: auto; // let content determine height on mobile
       }
     }
   }

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -205,7 +205,6 @@ $pale-blue: #E7EDF2;
     max-width: $max-width;
     display: grid;
     grid-template-columns: 3fr 1fr;
-    // justify-content: space-between;
 
     .primary-column {
       grid-column: 1;
@@ -234,6 +233,7 @@ $pale-blue: #E7EDF2;
 
     .sidebar-column {
       grid-column: 2;
+      max-height: 25px; // when sidebar is to the side, shrink so that it does not create space in primary column
       position: sticky;
       align-self: start;
       top: 0;
@@ -272,6 +272,7 @@ $pale-blue: #E7EDF2;
         grid-column: 1;
         margin: auto var(--unit-gutter);
         padding-top: 0px;
+        max-height: auto; // when sidebar is in the flow of content, content determines height
       }
     }
   }

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -91,20 +91,6 @@ const parsedFTVAEventScreeningDetails = computed(() => {
     }
   })
 })
-
-// LAYOUT FUNCTIONS
-// determine if mobile
-const isMobile = computed(() => {
-  return globalStore.winWidth <= 750 // 750px is the breakpoint for {$small}
-})
-// get the height of the sidebar content
-// & set padding to match mobile or desktop layout
-const sidebar = ref(0)
-const sidebarStyles = computed(() => {
-  return {
-    paddingBottom: isMobile.value ? '0px' : `calc(${sidebar.value?.clientHeight}px + 30px)`
-  }
-})
 </script>
 
 <template>
@@ -159,25 +145,17 @@ const sidebarStyles = computed(() => {
 
       <!-- sidebar slots in here on mobile -->
       <!-- on desktop sidebar is stickied to the side with css -->
-      <div
-        class="sidebar-column"
-        :style="sidebarStyles"
-      >
-        <div
-          ref="sidebar"
-          class="sidebar-content-wrapper"
-        >
-          <BlockEventDetail
-            :start-date="page.startDateWithTime"
-            :time="page.startDateWithTime"
-            :locations="page.location"
-          />
+      <div class="sidebar-column">
+        <BlockEventDetail
+          :start-date="page.startDateWithTime"
+          :time="page.startDateWithTime"
+          :locations="page.location"
+        />
 
-          <BlockInfo
-            v-if="page.ftvaTicketInformation && page.ftvaTicketInformation.length > 0"
-            :ftva-ticket-information="page.ftvaTicketInformation"
-          />
-        </div>
+        <BlockInfo
+          v-if="page.ftvaTicketInformation && page.ftvaTicketInformation.length > 0"
+          :ftva-ticket-information="page.ftvaTicketInformation"
+        />
       </div>
 
       <div class="primary-column bottom">
@@ -244,12 +222,13 @@ $pale-blue: #E7EDF2;
     position: relative;
     width: 100%;
     max-width: $max-width;
-    display: grid;
-    grid-template-columns: 3fr 1fr;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
 
     .primary-column {
-      grid-column: 1;
       margin-bottom: 0px;
+      width: 67%;
 
       .section-wrapper {
         padding-left: 0px;
@@ -277,11 +256,11 @@ $pale-blue: #E7EDF2;
     }
 
     .sidebar-column {
-      grid-column: 2;
       min-width: 280px;
-      height: 50px; // when sidebar is to the side, shrink so that it does not create space in primary column
+      width: 30%;
       position: sticky;
       align-self: start;
+      margin-left: auto;
       top: 0;
       will-change: top;
       padding-top: var(--space-2xl);
@@ -304,11 +283,21 @@ $pale-blue: #E7EDF2;
     min-height: 350px;
   }
 
+  @media #{$medium} {
+    .two-column>.primary-column {
+      width: 62%;
+    }
+  }
+
   @media #{$small} {
     .two-column {
+      display: grid;
       grid-template-columns: 1fr;
 
       .primary-column {
+        width: auto;
+        grid-column: 1;
+
         .section-wrapper {
           padding-left: var(--unit-gutter);
         }
@@ -319,6 +308,7 @@ $pale-blue: #E7EDF2;
       }
 
       .sidebar-column {
+        width: auto;
         position: relative;
         grid-column: 1;
         margin: auto var(--unit-gutter);


### PR DESCRIPTION
Connected to [APPS-2842](https://jira.library.ucla.edu/browse/APPS-2842)

**Page/Pages Created/updated:** [slug].vue 

**Notes:**

We originally thought this was a cardMeta component issue, but on inspection it was because the grid-layout forces the height of the elements in the grid to match. I reduced the sidebar height on larger screens to prevent this, ~~but it means that the sidebar content will scroll behind the bottom section content instead of stopping above it.~~ edit: I couldn't stand the look of the scroll-behind solution so I have added some inline styles powered by refs to dynamically add bottom-padding to prevent this.  

**Time Report:**

This took me 8ish hours to build this.

**Checklist:**

-   [X] I added github label for semantic versioning
-   [ ] I double checked it looks like the designs
-   [ ] I completed any required mobile breakpoint styling
-   [ ] I completed any required hover state styling
-   [ ] I included a working spec file
-   [X] I added notes above about how long it took to build this component
-   [ ] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review

[APPS-2842]: https://uclalibrary.atlassian.net/browse/APPS-2842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ