### PR TITLE
fix: APPS-2854 Page ftvaEvent query to title: eventTitle

### DIFF
--- a/gql/queries/FTVAEventDetail.gql
+++ b/gql/queries/FTVAEventDetail.gql
@@ -88,7 +88,7 @@ query FTVAEventDetail($slug: [String!]) {
         ... on ftvaEvent_ftvaEvent_Entry {
           id
           to: uri
-          title
+          title: eventTitle
           startDate: startDateWithTime @formatDateTime(format: "Y-m-d", timezone: "America/Los_Angeles")
           startTime: startDateWithTime @formatDateTime(format: "TH:i:s", timezone: "America/Los_Angeles")
           image: ftvaImage {


### PR DESCRIPTION
Connected to [APPS-2854](https://uclalibrary.atlassian.net/browse/APPS-2854)

https://deploy-preview-11--test-ftva.netlify.app/events/la-r%C3%A9gion-centrale-03-08-24

<img width="973" alt="Screenshot 2024-07-30 at 2 07 01 PM" src="https://github.com/user-attachments/assets/57afe465-42b9-4c0b-ab1a-366865964bea">




[APPS-2854]: https://uclalibrary.atlassian.net/browse/APPS-2854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ