### PR TITLE
fix: APPS-2844 maxwidth, which helps fix most carousel issues

### DIFF
--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -190,7 +190,7 @@ const parsedFTVAEventScreeningDetails = computed(() => {
 <style lang="scss" scoped>
 // VARS - TO DO move to global? reference tokens?
 // WIDTH, HEIGHT, SPACING
-$max-width: 928px;
+$max-width: 1160px;
 $banner-height: 520px;
 // COLORS
 $pale-blue: #E7EDF2;


### PR DESCRIPTION
Connected to [APPS-2844](https://jira.library.ucla.edu/browse/APPS-2844)

**Page/Pages Created/updated:** [slug].vue 

**Notes:**

During initial page review [Axa asked that we set the page max-width to 1160px](https://uclalibrary.slack.com/archives/C014BPS0YBX/p1722031120220339?thread_ts=1722028832.405809&cid=C014BPS0YBX)

I noticed during testing carousel style bugs earlier that the wider width prevents some of the carousel issues, so Id like to go ahead and make this change before changing carousel styles further.

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   [ ] I completed any required mobile breakpoint styling
-   [ ] I completed any required hover state styling
-   [ ] I included a working spec file
-   [ ] I added notes above about how long it took to build this component
-   [X] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-2844]: https://uclalibrary.atlassian.net/browse/APPS-2844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ