### PR TITLE
fix: APPS-2871 EventDetail page Screening titles are showing data from the wrong field

### DIFF
--- a/gql/queries/FTVAEventDetail.gql
+++ b/gql/queries/FTVAEventDetail.gql
@@ -30,17 +30,17 @@ query FTVAEventDetail($slug: [String!]) {
 
     ftvaEventScreeningDetails {
       ...on ftvaEventScreeningDetails_screeningDetails_BlockType {
-        screeningTitle
+        title: screeningTitle
         alternateTitle
-        languageTranslated
+        language: languageTranslated
         year
         country
         languageInfo
         runtime
-        screeningTags {
+        tagLabels: screeningTags {
           title
         }
-        descriptionOfScreening
+        text: descriptionOfScreening
         trailer
         image {
           ...on mediaAndDocuments_Asset {


### PR DESCRIPTION
Connected to [APPS-2871](https://jira.library.ucla.edu/browse/APPS-2871)

![Screenshot 2024-08-06 at 7 38 04 PM](https://github.com/user-attachments/assets/10fc0b68-98fe-4330-9aab-ad34037f2e56)


**Checklist:**
- [x] I added github label for semantic versioning
- [x] I double checked it looks like the designs

