### PR TITLE
fix: APPS-2874  Page SectionTeaserCard Link

### DIFF
--- a/gql/queries/FTVAEventDetail.gql
+++ b/gql/queries/FTVAEventDetail.gql
@@ -87,7 +87,7 @@ query FTVAEventDetail($slug: [String!]) {
       ftvaEvent {
         ... on ftvaEvent_ftvaEvent_Entry {
           id
-          to: uri
+          to: slug
           title: eventTitle
           startDate: startDateWithTime @formatDateTime(format: "Y-m-d", timezone: "America/Los_Angeles")
           startTime: startDateWithTime @formatDateTime(format: "TH:i:s", timezone: "America/Los_Angeles")


### PR DESCRIPTION
Connected to [APPS-2874](https://jira.library.ucla.edu/browse/APPS-2874)

https://deploy-preview-17--test-ftva.netlify.app/events/la-r%C3%A9gion-centrale-03-08-24

The link was wrong it doubled event
`/events/events/high-noon-10-20-23`


Acceptance Criteria
- [x] The SectionTeaserCard link works

<img width="453" alt="Screenshot 2024-08-06 at 8 52 10 PM" src="https://github.com/user-attachments/assets/04662a6a-dc5a-40d7-976f-e3e95c45b59f">

[APPS-2874]: https://uclalibrary.atlassian.net/browse/APPS-2874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ