### PR TITLE
fix: APPS-2870 Page TextDescription and GuestSpeakerre-arranged to fix text truncation problem

### DIFF
--- a/cypress/e2e/eventDetailPage.cy.js
+++ b/cypress/e2e/eventDetailPage.cy.js
@@ -4,6 +4,6 @@ describe('Event Detail page', () => {
 
     cy.get('h3.title-no-link').should('contain', 'TEST - La Région Centrale')
 
-    cy.percySnapshot({ widths: [768, 992, 1200] })
+    cy.percySnapshot('eventdetailpage', { widths: [768, 992, 1200] })
   })
 })

--- a/cypress/e2e/homepage.cy.js
+++ b/cypress/e2e/homepage.cy.js
@@ -18,6 +18,6 @@ describe('Website Homepage', () => {
     //   .should('have.attr', 'href', 'https://www.library.ucla.edu')
     // NavPrimary
 
-    cy.percySnapshot({ widths: [768, 992, 1200] })
+    // cy.percySnapshot({ widths: [768, 992, 1200] })
   })
 })

--- a/gql/queries/FTVAEventDetail.gql
+++ b/gql/queries/FTVAEventDetail.gql
@@ -18,12 +18,12 @@ query FTVAEventDetail($slug: [String!]) {
 
     # CardMeta
     title: eventTitle
-    ftvaEventIntroduction
     guestSpeaker
     tagLabels: ftvaEventFilters {
       title
       uri
     }
+    introduction
 
     eventDescription
     acknowledements: richText

--- a/gql/queries/FTVAEventDetail.gql
+++ b/gql/queries/FTVAEventDetail.gql
@@ -23,7 +23,7 @@ query FTVAEventDetail($slug: [String!]) {
       title
       uri
     }
-    introduction
+    introduction: ftvaEventIntroduction
 
     eventDescription
     acknowledements: richText

--- a/gql/queries/FTVAEventDetail.gql
+++ b/gql/queries/FTVAEventDetail.gql
@@ -20,7 +20,7 @@ query FTVAEventDetail($slug: [String!]) {
     title: eventTitle
     ftvaEventIntroduction
     guestSpeaker
-    ftvaEventFilters {
+    tagLabels: ftvaEventFilters {
       title
       uri
     }

--- a/gql/queries/FTVAEventDetail.gql
+++ b/gql/queries/FTVAEventDetail.gql
@@ -19,13 +19,13 @@ query FTVAEventDetail($slug: [String!]) {
     # CardMeta
     title: eventTitle
     ftvaEventIntroduction
-    eventDescription
+    guestSpeaker
     ftvaEventFilters {
       title
       uri
     }
 
-    guestSpeaker
+    eventDescription
     acknowledements: richText
 
     ftvaEventScreeningDetails {

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -126,9 +126,9 @@ const parsedFTVAEventScreeningDetails = computed(() => {
           <CardMeta
             :category="series[0]?.title"
             :title="page?.title"
+            :guest-speaker="page.guestSpeaker"
             :tag-labels="page.tagLabels"
             :introduction="page.introduction"
-            :guest-speaker="page.guestSpeaker"
           />
           <RichText
             v-if="page.eventDescription"

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -126,8 +126,8 @@ const parsedFTVAEventScreeningDetails = computed(() => {
           <CardMeta
             :category="series[0]?.title"
             :title="page?.title"
-            :guestSpeaker="page.guestSpeaker"
-            :tagLabels="page.tagLabels"
+            :guest-speaker="page.guestSpeaker"
+            :tag-labels="page.tagLabels"
             :introduction="page.introduction"
           />
           <RichText

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -126,8 +126,8 @@ const parsedFTVAEventScreeningDetails = computed(() => {
           <CardMeta
             :category="series[0]?.title"
             :title="page?.title"
-            :tag-labels="page.ftvaEventFilters"
-            :introduction="page.ftvaEventIntroduction"
+            :tag-labels="page.tagLabels"
+            :introduction="page.introduction"
             :guestSpeaker="page.guestSpeaker"
           />
           <RichText

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -128,11 +128,11 @@ const parsedFTVAEventScreeningDetails = computed(() => {
             :title="page?.title"
             :tag-labels="page.ftvaEventFilters"
             :introduction="page.ftvaEventIntroduction"
-            :text="page.eventDescription"
+            :guestSpeaker="page.guestSpeaker"
           />
           <RichText
-            v-if="page.guestSpeaker"
-            :rich-text-content="page.guestSpeaker"
+            v-if="page.eventDescription"
+            :rich-text-content="page.eventDescription"
           />
 
           <RichText

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -126,8 +126,8 @@ const parsedFTVAEventScreeningDetails = computed(() => {
           <CardMeta
             :category="series[0]?.title"
             :title="page?.title"
-            :guest-speaker="page.guestSpeaker"
-            :tag-labels="page.tagLabels"
+            :guestSpeaker="page.guestSpeaker"
+            :tagLabels="page.tagLabels"
             :introduction="page.introduction"
           />
           <RichText

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -128,7 +128,7 @@ const parsedFTVAEventScreeningDetails = computed(() => {
             :title="page?.title"
             :tag-labels="page.tagLabels"
             :introduction="page.introduction"
-            :guestSpeaker="page.guestSpeaker"
+            :guest-speaker="page.guestSpeaker"
           />
           <RichText
             v-if="page.eventDescription"


### PR DESCRIPTION
Connected to [APPS-2870](https://jira.library.ucla.edu/browse/APPS-2870) && [PR](https://github.com/UCLALibrary/ucla-library-website-components/pull/582)

1. This is the Nuxt part of this ticket to move the guestSpeaker into the CardMeta and the textDescription into a RichText component
2. This PR also contains changes to the Cypress tests to not take a screenshot of the home page and names the screenshot on the eventDetails page

**Checklist:**
- [x] I added a github label for semantic versioning
- [x] I double checked it looks like the designs

[APPS-2870]: https://uclalibrary.atlassian.net/browse/APPS-2870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ