### PR TITLE
fix: APPS-2869 Remove fixed height on embedded video sizer

### DIFF
--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -187,10 +187,7 @@ const parsedFTVAEventScreeningDetails = computed(() => {
   </main>
 </template>
 
-<style
-  lang="scss"
-  scoped
->
+<style lang="scss" scoped>
 // VARS - TO DO move to global? reference tokens?
 // WIDTH, HEIGHT, SPACING
 $max-width: 1160px;
@@ -251,12 +248,6 @@ $pale-blue: #E7EDF2;
     // TODO when component is patched, remove styles?
     :deep(figure.responsive-video:not(:has(.video-embed))) {
       display: none;
-    }
-
-    :deep(figure.responsive-video) {
-      .sizer {
-        height: 568px; // TODO ask UX if FTVA videos on this page have fixed height or not
-      }
     }
 
     .sidebar-column {


### PR DESCRIPTION
Connected to [APPS-2869](https://jira.library.ucla.edu/browse/APPS-2869)

**Page updated:** /events/[slug].vue

**Notes:**
- Removed fixed height value set on ResponsiveVideo sizer element; this reduced excess negative space underneath embedded videos

**Before:**
![before](https://github.com/user-attachments/assets/61d03f24-53d3-4a52-9809-a8749e328526)

**After:**
![after](https://github.com/user-attachments/assets/548f3aae-46b2-4f23-b0e2-1f15097386ec)

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I requested a PR review from dev team
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~

[APPS-2869]: https://uclalibrary.atlassian.net/browse/APPS-2869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ