### PR TITLE
fix: set aspect ratio for images

### DIFF
--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -103,6 +103,7 @@ const parsedFTVAEventScreeningDetails = computed(() => {
       <ResponsiveImage
         v-if="parsedImage.length === 1"
         :media="parsedImage[0].image[0]"
+        :aspect-ratio="43.103"
       >
         <template #credit>
           {{ parsedImage[0]?.creditText }}

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -109,7 +109,7 @@ const parsedFTVAEventScreeningDetails = computed(() => {
         :aspect-ratio="43.103"
       >
         <template
-          v-if="parsedImage.creditText"
+          v-if="parsedImage[0].creditText"
           #credit
         >
           {{ parsedImage[0]?.creditText }}

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -108,7 +108,10 @@ const parsedFTVAEventScreeningDetails = computed(() => {
         :media="parsedImage[0].image[0]"
         :aspect-ratio="43.103"
       >
-        <template #credit>
+        <template
+          v-if="parsedImage.creditText"
+          #credit
+        >
           {{ parsedImage[0]?.creditText }}
         </template>
       </ResponsiveImage>
@@ -191,10 +194,7 @@ const parsedFTVAEventScreeningDetails = computed(() => {
   </main>
 </template>
 
-<style
-  lang="scss"
-  scoped
->
+<style lang="scss" scoped>
 // VARS - TO DO move to global? reference tokens?
 // WIDTH, HEIGHT, SPACING
 $max-width: 1160px;
@@ -210,13 +210,9 @@ $pale-blue: #E7EDF2;
     content: '';
     position: absolute;
     background-color: $pale-blue;
-    aspect-ratio: 2.31 / 1;
+    aspect-ratio: 1440 / 520;
     width: 100%;
     z-index: -1;
-  }
-
-  .lightbox-container {
-    aspect-ratio: 2.31 / 1;
   }
 
   .one-column {

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -210,9 +210,13 @@ $pale-blue: #E7EDF2;
     content: '';
     position: absolute;
     background-color: $pale-blue;
-    height: $banner-height;
+    aspect-ratio: 2.31 / 1;
     width: 100%;
     z-index: -1;
+  }
+
+  .lightbox-container {
+    aspect-ratio: 2.31 / 1;
   }
 
   .one-column {

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -116,7 +116,7 @@ const parsedFTVAEventScreeningDetails = computed(() => {
         :aspect-ratio="43.103"
       >
         <template
-          v-if="parsedImage[0].creditText"
+          v-if="parsedImage[0]?.creditText"
           #credit
         >
           {{ parsedImage[0]?.creditText }}


### PR DESCRIPTION
Connected to [APPS-2880](https://jira.library.ucla.edu/browse/APPS-2880)

**Notes:**

The image at the top of the page should have a ratio of 1 (tall) to 2.31 (long), which works out to 1/2.31 = ~.43103
Responsive Image component expects this as a percentage so the prop is passed as 43.103.

Once that was fixed, it was noticed that the blue banner at the top of the screen needed an aspect ratio as well, so that was set. 

I also fixed the issue with the pagelayout rendering the credit text whether or not there was any.

UX reported that the carousel should be changed to the same aspect ratio, so I added that to the APPS-2844

**Time Report:**

It took me 4 hours to build & test this.

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   [X] I added notes above about how long it took to build this component
-   [X] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-2880]: https://uclalibrary.atlassian.net/browse/APPS-2880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ