### PR TITLE
fix: APPS-2878 Show Only Upcoming Events in a Series

### DIFF
--- a/gql/queries/FTVAEventDetail.gql
+++ b/gql/queries/FTVAEventDetail.gql
@@ -84,7 +84,7 @@ query FTVAEventDetail($slug: [String!]) {
       slug
       typeHandle
       title
-      ftvaEvent {
+      ftvaEvent(startDateWithTime: ">= now") {
         ... on ftvaEvent_ftvaEvent_Entry {
           id
           to: slug


### PR DESCRIPTION
Connected to [APPS-2878](https://jira.library.ucla.edu/browse/APPS-2878)

**Page updated:** /events/[slug].vue

**Notes:**
- Updated query to fetch upcoming events
- Refactored computed property for parsing event series
- Updated template to reference parsed series array

**Before:**
![before](https://github.com/user-attachments/assets/d8205807-158f-4b23-876c-c4201b8b681b)

**After:**
![after](https://github.com/user-attachments/assets/675d8f4f-5c6a-4d40-ab63-ecfc53918c6d)

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I assigned this PR to someone to review
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~



[APPS-2878]: https://uclalibrary.atlassian.net/browse/APPS-2878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ