### PR TITLE
fix: APPS-2884 Temporarily disable image query

### DIFF
--- a/gql/queries/FTVAEventList.gql
+++ b/gql/queries/FTVAEventList.gql
@@ -1,4 +1,4 @@
-#import "../gql/fragments/Image.gql"
+# import "../gql/fragments/Image.gql"
 
 query FTVAEventList {
   entries(section: ["ftvaEvent"], orderBy: "postDate") {
@@ -6,9 +6,9 @@ query FTVAEventList {
     id
     title: eventTitle
     to: uri
-    image: ftvaImage {
-      ...Image
-    }
+    # image: ftvaImage {
+    #  ...Image
+    # }
     startDateWithTime
     startDate: startDateWithTime @formatDateTime(format: "Y-m-d", timezone: "America/Los_Angeles")
     startTime: startDateWithTime @formatDateTime(format: "TH:i:s", timezone: "America/Los_Angeles")

--- a/gql/queries/FTVAEventSeriesList.gql
+++ b/gql/queries/FTVAEventSeriesList.gql
@@ -1,4 +1,4 @@
-#import "../gql/fragments/Image.gql"
+# import "../gql/fragments/Image.gql"
 
 query FTVAEventSeriesList {
   entries(section: ["ftvaEventSeries"], orderBy: "postDate") {
@@ -9,9 +9,9 @@ query FTVAEventSeriesList {
     ... on ftvaEventSeries_eventSeries_Entry {
       id
       eventDescription
-      image: ftvaImage {
-        ...Image
-      }
+      # image: ftvaImage {
+      #  ...Image
+      # }
       startDate @formatDateTime(format: "Y-m-d", timezone: "America/Los_Angeles")
       endDate @formatDateTime(format: "Y-m-d", timezone: "America/Los_Angeles")
     }


### PR DESCRIPTION
Connected to [APPS-2884](https://jira.library.ucla.edu/browse/APPS-2884)

**Notes:**
- Production build sometimes fails on sample event listing page; this PR temporarily resolves this by disabling the image query field in the EventList and EventSeriesList `gql` files; see ticket for more details

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I requested a PR review from the Dev team
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~

[APPS-2884]: https://uclalibrary.atlassian.net/browse/APPS-2884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ