### PR TITLE
fix: APPS-2893 set max height blue box for large screens

### DIFF
--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -218,7 +218,8 @@ $pale-blue: #E7EDF2;
     position: absolute;
     background-color: $pale-blue;
     aspect-ratio: 1440 / 520;
-    max-height: 518px;
+    max-height: 518px; //prevent overflow on large screens
+    min-height: 225px; //prevent too much shrinking on small screens
     width: 100%;
     z-index: -1;
   }

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -218,6 +218,7 @@ $pale-blue: #E7EDF2;
     position: absolute;
     background-color: $pale-blue;
     aspect-ratio: 1440 / 520;
+    max-height: 518px;
     width: 100%;
     z-index: -1;
   }


### PR DESCRIPTION
Connected to [APPS-2893](https://jira.library.ucla.edu/browse/APPS-2893)

**Page/Pages Created/updated:** slug.vue from #{issue number}

**Notes:**

The blue element at the top of page was recently made responsive, but we did not set a max-height for large screens. This PR fixes that. 

**Time Report:**

This took me .5 hours to build this.

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   [X] I completed any required mobile breakpoint styling
-   [ ] I completed any required hover state styling
-   [ ] I included a working spec file
-   [X] I added notes above about how long it took to build this component
-   [X] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-2893]: https://uclalibrary.atlassian.net/browse/APPS-2893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ