### PR TITLE
feat: APPS-2910 assemble event series page

### DIFF
--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -74,6 +74,7 @@ button {
     z-index: 200;
 }
 
+// Page Structure
 .page {
     >* {
         margin-left: auto;

--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -3,6 +3,7 @@
     --max-width: 1160px;
     // COLORS
     --pale-blue: #E7EDF2;
+    --subtitle-grey: #676767;
 }
 
 html {

--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -67,13 +67,20 @@ button {
 // Z-indexs
 .header-sticky {
     z-index: 100;
+
+    :deep(nav.nav-primary) {
+
+        // TODO get this working?
+        .section-name {
+            overflow: hidden;
+        }
+    }
 }
 
 .header-main {
     z-index: 200;
 }
 
-// Page Structure
 .page {
     >* {
         margin-left: auto;

--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -1,3 +1,10 @@
+// site-specific variables
+:root {
+    --max-width: 1160px;
+    // COLORS
+    --pale-blue: #E7EDF2;
+}
+
 html {
     box-sizing: border-box;
 }

--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -67,14 +67,6 @@ button {
 // Z-indexs
 .header-sticky {
     z-index: 100;
-
-    :deep(nav.nav-primary) {
-
-        // TODO get this working?
-        .section-name {
-            overflow: hidden;
-        }
-    }
 }
 
 .header-main {

--- a/cypress/e2e/eventSeriesDetailPage.cy.js
+++ b/cypress/e2e/eventSeriesDetailPage.cy.js
@@ -2,6 +2,6 @@ describe('Event Series Detail page', () => {
   it('Visit the Homepage', () => {
     cy.visit('/series/step-up-series')
 
-    cy.percySnapshot({ widths: [768, 992, 1200] })
+    cy.percySnapshot('eventseriesdetailpage',{ widths: [768, 992, 1200] })
   })
 })

--- a/cypress/e2e/eventSeriesDetailPage.cy.js
+++ b/cypress/e2e/eventSeriesDetailPage.cy.js
@@ -1,0 +1,7 @@
+describe('Event Series Detail page', () => {
+  it('Visit the Homepage', () => {
+    cy.visit('/series/step-up-series')
+
+    cy.percySnapshot({ widths: [768, 992, 1200] })
+  })
+})

--- a/cypress/e2e/eventSeriesDetailPage.cy.js
+++ b/cypress/e2e/eventSeriesDetailPage.cy.js
@@ -2,6 +2,6 @@ describe('Event Series Detail page', () => {
   it('Visit the Homepage', () => {
     cy.visit('/series/step-up-series')
 
-    cy.percySnapshot('eventseriesdetailpage',{ widths: [768, 992, 1200] })
+    cy.percySnapshot('eventseriesdetailpage', { widths: [768, 992, 1200] })
   })
 })

--- a/gql/queries/FTVAEventSeriesDetail.gql
+++ b/gql/queries/FTVAEventSeriesDetail.gql
@@ -47,29 +47,60 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
     }
   }
   upcomingEvents: entries(section: "ftvaEvent", relatedToEntries: { section: "ftvaEventSeries", slug: $slug }, startDateWithTime: ">= now", orderBy: "startDateWithTime ASC") {
-      uri
+      to: uri
       sectionHandle
-      eventTitle
+      title: eventTitle
       startDateWithTime
-      ftvaImage {
+      startDate: startDateWithTime @formatDateTime(format: "Y-m-d", timezone: "America/Los_Angeles")
+    	startTime: startDateWithTime @formatDateTime(format: "TH:i:s", timezone: "America/Los_Angeles")
+      image: ftvaImage {
         ...Image
       }
-      ftvaEventFilters {
+      tagLabels: ftvaEventFilters {
         title
       }
   }
-  pastEvents: entries(section: "ftvaEvent",  relatedToEntries: { section: "ftvaEventSeries", slug: $slug }, startDateWithTime: "< now", orderBy: "startDateWithTime ASC") {
-    uri
-    sectionHandle
-    eventTitle
-    startDateWithTime
-    ftvaImage {
+  pastEvents: entries(section: "ftvaEvent", relatedToEntries: { section: "ftvaEventSeries", slug: $slug }, startDateWithTime: "< now", orderBy: "startDateWithTime ASC") {
+    to: uri
+    title: eventTitle
+    startDateWithTime @formatDateTime(
+                    format: "Y-m-d\\TH:i"
+                    timezone: "America/Los_Angeles"
+                )
+    startDate: startDateWithTime @formatDateTime(format: "Y-m-d", timezone: "America/Los_Angeles")
+    startTime: startDateWithTime @formatDateTime(format: "TH:i:s", timezone: "America/Los_Angeles")
+    image: ftvaImage {
       ...Image
     }
-    ftvaEventFilters {
+    tagLabels: ftvaEventFilters {
       title
     }
   }
+  # CAN BE REMOVED ONCE NEW ONES ARE WORKING
+  # upcomingEvents: entries(section: "ftvaEvent", relatedToEntries: { section: "ftvaEventSeries", slug: $slug }, startDateWithTime: ">= now", orderBy: "startDateWithTime ASC") {
+  #     uri
+  #     sectionHandle
+  #     eventTitle
+  #     startDateWithTime
+  #     ftvaImage {
+  #       ...Image
+  #     }
+  #     ftvaEventFilters {
+  #       title
+  #     }
+  # }
+  # pastEvents: entries(section: "ftvaEvent",  relatedToEntries: { section: "ftvaEventSeries", slug: $slug }, startDateWithTime: "< now", orderBy: "startDateWithTime ASC") {
+  #   uri
+  #   sectionHandle
+  #   eventTitle
+  #   startDateWithTime
+  #   ftvaImage {
+  #     ...Image
+  #   }
+  #   ftvaEventFilters {
+  #     title
+  #   }
+  # }
   otherSeriesOngoing: entries(section: "ftvaEventSeries", limit: 3, ongoing: true) {
     uri
     sectionHandle

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
 		"nuxt-graphql-request": "^7.0.5",
 		"sass": "^1.66.1",
 		"ucla-library-design-tokens": "^5.22.0",
-		"ucla-library-website-components": "3.17.1"
+		"ucla-library-website-components": "3.18.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
 		"nuxt-graphql-request": "^7.0.5",
 		"sass": "^1.66.1",
 		"ucla-library-design-tokens": "^5.22.0",
-		"ucla-library-website-components": "3.15.1"
+		"ucla-library-website-components": "3.16.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
 		"nuxt-graphql-request": "^7.0.5",
 		"sass": "^1.66.1",
 		"ucla-library-design-tokens": "^5.22.0",
-		"ucla-library-website-components": "3.12.0"
+		"ucla-library-website-components": "3.15.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
 		"nuxt-graphql-request": "^7.0.5",
 		"sass": "^1.66.1",
 		"ucla-library-design-tokens": "^5.22.0",
-		"ucla-library-website-components": "3.16.0"
+		"ucla-library-website-components": "3.17.1"
 	}
 }

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -264,7 +264,6 @@ const parsedFTVAEventScreeningDetails = computed(() => {
     }
   }
 
-  /* .page-event-detail .two-column .sidebar-column */
   .two-column {
     position: relative;
     width: 100%;

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -85,8 +85,9 @@ const parsedFtvaEventSeries = computed(() => {
   }
 
   // Destructure each series item object and its image object
-  const seriesEvents = firstSeries.ftvaEvent.map(({ image, ...rest }) => ({
+  const seriesEvents = firstSeries.ftvaEvent.map(({ image, to, ...rest }) => ({
     ...rest,
+    to: `/events/${to}`,
     image: image && image.length > 0 ? image[0] : null,
   }))
 
@@ -119,6 +120,8 @@ const parsedFTVAEventScreeningDetails = computed(() => {
         class="breadcrumb"
         data-test="breadcrumb"
         :title="page?.title"
+        to="/events"
+        parent-title="Events"
       />
 
       <ResponsiveImage

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -120,8 +120,6 @@ const parsedFTVAEventScreeningDetails = computed(() => {
         class="breadcrumb"
         data-test="breadcrumb"
         :title="page?.title"
-        to="/events"
-        parent-title="Events"
       />
 
       <ResponsiveImage

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -228,6 +228,7 @@ const parsedFTVAEventScreeningDetails = computed(() => {
       v-if="parsedFtvaEventSeries && parsedFtvaEventSeries.length > 0"
       section-title="Upcoming events in this series"
       theme="paleblue"
+      class="series-section-wrapper"
     >
       <SectionTeaserCard
         v-if="parsedFtvaEventSeries && parsedFtvaEventSeries.length > 0"
@@ -299,6 +300,8 @@ const parsedFTVAEventScreeningDetails = computed(() => {
       display: none;
     }
 
+    // move these styles to a component so they can be reused & kept in sync
+    // with /series/[slug].vue
     .sidebar-column {
       min-width: 314px;
       width: 30%;
@@ -307,7 +310,7 @@ const parsedFTVAEventScreeningDetails = computed(() => {
       top: 0;
       right: 0;
       padding-top: var(--space-2xl);
-      padding-bottom: 20px;
+      padding-bottom: 40px;
 
       .sidebar-content-wrapper {
         position: sticky;
@@ -366,6 +369,13 @@ const parsedFTVAEventScreeningDetails = computed(() => {
         height: auto; // let content determine height on mobile
       }
     }
+  }
+}
+
+// TEMPORARY STYLES THAT SHOULD BE PART OF SECTIONWRAPPER
+.series-section-wrapper {
+  :deep(.section-header) {
+    margin-bottom: 28px;
   }
 }
 </style>

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -239,13 +239,6 @@ const parsedFTVAEventScreeningDetails = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-// VARS - TO DO move to global? reference tokens?
-// WIDTH, HEIGHT, SPACING
-$max-width: 1160px;
-$banner-height: 520px;
-// COLORS
-$pale-blue: #E7EDF2;
-
 // PAGE STYLES
 .page-event-detail {
   position: relative;
@@ -253,7 +246,7 @@ $pale-blue: #E7EDF2;
   &:before {
     content: '';
     position: absolute;
-    background-color: $pale-blue;
+    background-color: var(--pale-blue);
     aspect-ratio: 1440 / 520;
     max-height: 518px; //prevent overflow on large screens
     min-height: 225px; //prevent too much shrinking on small screens
@@ -263,7 +256,7 @@ $pale-blue: #E7EDF2;
 
   .one-column {
     width: 100%;
-    max-width: $max-width;
+    max-width: var(--max-width);
     margin: 0 auto;
 
     :deep(.nav-breadcrumb) {
@@ -275,7 +268,7 @@ $pale-blue: #E7EDF2;
   .two-column {
     position: relative;
     width: 100%;
-    max-width: $max-width;
+    max-width: var(--max-width);
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -257,9 +257,9 @@ onMounted(() => {
             title="Past Events"
             class="tab-content"
           >
-            <template v-if="pastEvents && pastEvents.length > 0">
+            <template v-if="parsedPastEvents && parsedPastEvents.length > 0">
               <SectionTeaserList
-                :items="pastEvents"
+                :items="parsedPastEvents"
                 component-name="BlockCardThreeColumn"
                 n-shown="10"
                 class="tabbed-event-list"
@@ -464,6 +464,7 @@ onMounted(() => {
 // TEMPORARY STYLES THAT SHOULD BE PART OF BLOCKCARDTHREECOLUMN & SECTIONTEASERLIST
 .tabbed-event-list {
   max-width: none;
+  padding: 2.5%;
 
   :deep(.list-item) {
     position: relative;
@@ -471,13 +472,15 @@ onMounted(() => {
     padding-bottom: 0;
     border-bottom: transparent;
 
-    &:after {
-      content: '';
-      width: 95%;
-      position: absolute;
-      left: 2.5%;
-      bottom: -22px;
-      border-bottom: 1px solid #e7edf2;
+    &:not(:last-child) {
+      &:after {
+        content: '';
+        width: 95%;
+        position: absolute;
+        left: 2.5%;
+        bottom: -22px;
+        border-bottom: 1px solid #e7edf2;
+      }
     }
 
     .day-month-date,

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -131,7 +131,10 @@ onMounted(() => {
         :media="parsedImage[0].image[0]"
         :aspect-ratio="43.103"
       >
-        <template>
+        <template
+          v-if="parsedImage[0]?.creditText"
+          #credit
+        >
           {{ parsedImage[0]?.creditText }}
         </template>
       </ResponsiveImage>
@@ -189,7 +192,6 @@ onMounted(() => {
         <TabList
           ref="tabs"
           alignment="left"
-          @change="console.log('tab changed')"
         >
           <TabItem
             title="Upcoming Events"
@@ -308,7 +310,6 @@ onMounted(() => {
     }
 
     // SECTION SCREENING DETAILS
-    // TODO when component is patched, remove styles?
     :deep(figure.responsive-video:not(:has(.video-embed))) {
       display: none;
     }
@@ -342,12 +343,12 @@ onMounted(() => {
   }
 
   .tab-content {
-    // min-height: 200px;
-    // text-align: center;
+    min-height: 200px;
+    text-align: center;
 
-    // .empty-tab {
-    //   padding: 100px 0;
-    // }
+    .empty-tab {
+      padding: 100px 0;
+    }
   }
 
   /* makes all EventSeries same height */

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -110,7 +110,6 @@ watch(globalStore, (newVal, oldVal) => {
 // Track height of sidebar and ensure main content as at least as tall
 const sidebar = ref(null)
 const primaryCol = ref(null)
-const tabs = ref(null)
 
 watch([isMobile, sidebar], ([newValIsMobile, newValSidebar], [oldValGlobalStore, oldValSidebar]) => {
   if (newValIsMobile === true) {
@@ -173,8 +172,13 @@ onMounted(() => {
           <CardMeta
             category="Series"
             :title="page?.title"
-            :text="page.eventDescription"
+            :text="page?.richText"
+            :introduction="page?.ftvaEventIntroduction"
             :guest-speaker="page?.guestSpeaker"
+          />
+          <RichText
+            v-if="page?.eventDescription"
+            :rich-text-content="page?.eventDescription"
           />
         </SectionWrapper>
       </div>
@@ -201,10 +205,7 @@ onMounted(() => {
 
     <div class="full-width">
       <SectionWrapper theme="paleblue">
-        <TabList
-          ref="tabs"
-          alignment="left"
-        >
+        <TabList alignment="left">
           <TabItem
             title="Upcoming Events"
             class="tab-content"
@@ -353,11 +354,17 @@ onMounted(() => {
     }
   }
 
+  :deep(.tab-list-body) {
+    background: none;
+  }
+
   .tab-content {
     min-height: 200px;
     text-align: center;
 
     .empty-tab {
+      @include ftva-subtitle-1;
+      color: var(--subtitle-grey);
       padding: 100px 0;
     }
   }

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -39,14 +39,6 @@ const pastEvents = ref(_get(data.value, 'pastEvents', {}))
 const otherSeriesOngoing = ref(_get(data.value, 'otherSeriesOngoing', {}))
 const otherSeriesUpcoming = ref(_get(data.value, 'otherSeriesUpcoming', {}))
 
-// Track height of sidebar and ensure main content as at least as tall
-const sidebar = ref(null)
-const primaryCol = ref(null)
-watch(sidebar, (newVal) => {
-  primaryCol.value.style.minHeight = `${newVal.clientHeight + 125}px`
-  // TODO MAKE ALL THIS WORK MOBILE, disable of is mobile?
-}, { deep: true })
-
 watch(data, (newVal, oldVal) => {
   console.log('In watch preview enabled, newVal, oldVal', newVal, oldVal)
   page.value = _get(newVal, 'ftvaEventSeries', {})
@@ -74,6 +66,7 @@ const parsedCarouselData = computed(() => {
   })
 })
 
+// Transform data for Other Series Section
 // This section only shows 3 items max, and prioritizes upcoming events over ongoing
 const parsedOtherSeries = computed(() => {
   // fail gracefully if data does not exist (server-side)
@@ -84,11 +77,11 @@ const parsedOtherSeries = computed(() => {
   // Get first 3 events
   otherSeries = otherSeries.slice(0, 3)
 
-  // Transform data for SectionTeaserCard
+  // Transform data
   otherSeries = otherSeries.map((item, index) => {
     return {
       ...item,
-      to: item.uri,
+      to: item.uri.replace('series/', ''), // remove 'series/' from uri
       startDate: item.startDate ? item.startDate : null,
       endDate: item.endDate ? item.endDate : null,
       ongoing: item.ongoing,
@@ -98,6 +91,26 @@ const parsedOtherSeries = computed(() => {
   })
   return otherSeries
 })
+
+// LAYOUT & STYLES
+// Track height of sidebar and ensure main content as at least as tall
+const sidebar = ref(null)
+const primaryCol = ref(null)
+const tabs = ref(null)
+// defineExpose({
+//   tabs
+// })
+watch(sidebar, (newVal) => {
+  primaryCol.value.style.minHeight = `${newVal.clientHeight + 125}px`
+  // TODO ADD MOBILE CONDITION, disable this logic if is mobile?
+}, { deep: true })
+
+onMounted(() => {
+  console.log('mounted')
+  // get tab refs so we can watch for tab change
+  // console.log('tabs', tabs.value.activeTab)
+})
+
 </script>
 
 <template>
@@ -154,14 +167,13 @@ const parsedOtherSeries = computed(() => {
           ref="sidebar"
           class="sidebar-content-wrapper"
         >
-          <!-- re-enable this when ongoing data
-            :start-date="page?.startDateWithTime"
-            :time="page?.startDateWithTime"
-            -->
-          <!-- <BlockEventDetail
+          <BlockEventDetail
             data-test="event-details"
+            :start-date="page?.startDate"
+            :end-date="page?.endDate"
+            :ongoing="page?.ongoing"
             :locations="page?.location"
-          /> -->
+          />
           <BlockInfo
             v-if="page?.ftvaTicketInformation && page?.ftvaTicketInformation.length > 0"
             data-test="ticket-info"
@@ -173,42 +185,45 @@ const parsedOtherSeries = computed(() => {
 
     <div class="full-width">
       <SectionWrapper theme="paleblue">
-        <tab-list alignment="left">
-          <tab-item
+        <!-- TODO listen for event or increment counter on click -->
+        <TabList
+          ref="tabs"
+          alignment="left"
+          @change="console.log('tab changed')"
+        >
+          <TabItem
             title="Upcoming Events"
             class="tab-content"
           >
-            <template v-if="upcomingEvents && upcomingEvents.length > 0">
-              <!-- <SectionTeaserCard :items="upcomingEvents" /> -->
+            <!-- <template v-if="upcomingEvents && upcomingEvents.length > 0">
               {{ upcomingEvents }}
             </template>
-            <template v-else>
-              <p class="empty-tab">
-                There are no upcoming events in this series.
-              </p>
-            </template>
-          </tab-item>
+            <template v-else> -->
+            <p class="empty-tab">
+              There are no upcoming events in this series.
+            </p>
+            <!-- </template> -->
+          </TabItem>
 
-          <tab-item
+          <TabItem
             title="Past Events"
             class="tab-content"
           >
-            <template v-if="pastEvents && pastEvents.length > 0">
-              <!-- <SectionTeaserCard :items="upcomingEvents" /> -->
+            <!-- <template v-if="pastEvents && pastEvents.length > 0">
               {{ pastEvents }}
             </template>
-            <template v-else>
-              <p class="empty-tab">
-                There are no upcoming events in this series.
-              </p>
-            </template>
-          </tab-item>
-        </tab-list>
+            <template v-else> -->
+            <p class="empty-tab">
+              There are no past events in this series.
+            </p>
+            <!-- </template> -->
+          </TabItem>
+        </TabList>
       </SectionWrapper>
     </div>
 
-    <!-- <SectionWrapper>
-      <h2>PAGE</h2>
+    <SectionWrapper>
+      <!-- <h2>PAGE</h2>
       <pre>{{ page }}</pre>
       <hr>
       <h2>UpcomingEvents</h2>
@@ -222,8 +237,8 @@ const parsedOtherSeries = computed(() => {
       <hr>
       <h2>Other Series Upcoming</h2>
       <pre>{{ otherSeriesUpcoming }}</pre>
-      <hr>
-    </SectionWrapper> -->
+      <hr> -->
+    </SectionWrapper>
 
     <!-- TODO: full-width column needed? -->
     <SectionWrapper
@@ -327,12 +342,12 @@ const parsedOtherSeries = computed(() => {
   }
 
   .tab-content {
-    min-height: 200px;
-    text-align: center;
+    // min-height: 200px;
+    // text-align: center;
 
-    .empty-tab {
-      padding: 100px 0;
-    }
+    // .empty-tab {
+    //   padding: 100px 0;
+    // }
   }
 
   /* makes all EventSeries same height */

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -492,7 +492,6 @@ onMounted(() => {
       border: 0;
       margin-bottom: 0;
       padding-bottom: 0;
-      border-radius: 0 0 35px 25px;
     }
 
     // Breakpoints

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -102,10 +102,11 @@ const parsedOtherSeries = computed(() => {
 const globalStore = useGlobalStore()
 const isMobile = ref(false)
 watch(globalStore, (newVal, oldVal) => {
-  isMobile.value = globalStore.winWidth <= 1024
+  isMobile.value = globalStore.winWidth <= 750
 })
 
 // LAYOUT & STYLES
+// TO DO THIS SECTION MAY BE WORTH ADDING TO 2 COL SIDE BAR LAYOUT
 // Track height of sidebar and ensure main content as at least as tall
 const sidebar = ref(null)
 const primaryCol = ref(null)
@@ -121,7 +122,7 @@ watch([isMobile, sidebar], ([newValIsMobile, newValSidebar], [oldValGlobalStore,
 
 // globalstore state is lost when error page is generated , this is hack to repopulate state on client side
 onMounted(() => {
-  isMobile.value = globalStore.winWidth <= 1024
+  isMobile.value = globalStore.winWidth <= 750 // 750px is the breakpoint for mobile
 })
 </script>
 

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -82,6 +82,7 @@ const parsedUpcomingEvents = computed(() => {
   return upcomingEvents.value.map((item, index) => {
     return {
       ...item,
+      to: `/${item.to}`,
       image: item.image && item.image.length > 0 ? item.image[0] : null
     }
   })
@@ -95,6 +96,7 @@ const parsedPastEvents = computed(() => {
   return pastEvents.value.map((item, index) => {
     return {
       ...item,
+      to: `/${item.to}`,
       image: item.image && item.image.length > 0 ? item.image[0] : null
     }
   })
@@ -117,7 +119,7 @@ const parsedOtherSeries = computed(() => {
   otherSeries = otherSeries.map((item, index) => {
     return {
       ...item,
-      to: item.uri.replace('series/', ''), // remove 'series/' from uri
+      to: `/${item.uri}`, // remove 'series/' from uri
       startDate: item.startDate ? item.startDate : null,
       endDate: item.endDate ? item.endDate : null,
       ongoing: item.ongoing,
@@ -163,7 +165,7 @@ onMounted(() => {
     <div class="one-column">
       <NavBreadcrumb
         class="breadcrumb"
-        :title="page.title"
+        :title="page?.title"
         to="/series"
         parent-title="Screening Series"
       />
@@ -241,10 +243,11 @@ onMounted(() => {
             class="tab-content"
           >
             <template v-if="parsedUpcomingEvents && parsedUpcomingEvents.length > 0">
+              <!-- :n-shown="10"  this prop does not do anything if theme is ftva-->
               <SectionTeaserList
                 :items="parsedUpcomingEvents"
                 component-name="BlockCardThreeColumn"
-                n-shown="10"
+                :n-shown="10"
                 class="tabbed-event-list"
               />
             </template>

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -124,7 +124,7 @@ const parsedOtherSeries = computed(() => {
       endDate: item.endDate ? item.endDate : null,
       ongoing: item.ongoing,
       sectionHandle: item.sectionHandle, // 'ftvaEventSeries'
-      image: item.ftvaImage[0],
+      image: item.ftvaImage && item.ftvaImage.length > 0 ? item.ftvaImage[0] : null,
     }
   })
   return otherSeries

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -39,8 +39,13 @@ const pastEvents = ref(_get(data.value, 'pastEvents', {}))
 const otherSeriesOngoing = ref(_get(data.value, 'otherSeriesOngoing', {}))
 const otherSeriesUpcoming = ref(_get(data.value, 'otherSeriesUpcoming', {}))
 
-// TODO get sidebar height and set container height to it if not as big
+// Track height of sidebar and ensure main content as at least as tall
 const sidebar = ref(null)
+const primaryCol = ref(null)
+watch(sidebar, (newVal) => {
+  primaryCol.value.style.minHeight = `${newVal.clientHeight + 125}px`
+  // TODO MAKE ALL THIS WORK MOBILE, disable of is mobile?
+}, { deep: true })
 
 watch(data, (newVal, oldVal) => {
   console.log('In watch preview enabled, newVal, oldVal', newVal, oldVal)
@@ -71,7 +76,7 @@ const parsedCarouselData = computed(() => {
 
 // This section only shows 3 items max, and prioritizes upcoming events over ongoing
 const parsedOtherSeries = computed(() => {
-  // fail gracefully if data does not exist (server-side) 
+  // fail gracefully if data does not exist (server-side)
   if (!otherSeriesUpcoming.value && !otherSeriesOngoing.value)
     return []
 
@@ -87,7 +92,7 @@ const parsedOtherSeries = computed(() => {
       startDate: item.startDate ? item.startDate : null,
       endDate: item.endDate ? item.endDate : null,
       ongoing: item.ongoing,
-      sectionHandle: item.sectionHandle, //'ftvaEventSeries'
+      sectionHandle: item.sectionHandle, // 'ftvaEventSeries'
       image: item.ftvaImage[0],
     }
   })
@@ -131,7 +136,10 @@ const parsedOtherSeries = computed(() => {
     </div>
 
     <div class="two-column">
-      <div class="primary-column top">
+      <div
+        ref="primaryCol"
+        class="primary-column top"
+      >
         <SectionWrapper>
           <CardMeta
             category="Series"
@@ -146,7 +154,7 @@ const parsedOtherSeries = computed(() => {
           ref="sidebar"
           class="sidebar-content-wrapper"
         >
-          <!-- re-enable this when ongoing data           
+          <!-- re-enable this when ongoing data
             :start-date="page?.startDateWithTime"
             :time="page?.startDateWithTime"
             -->
@@ -161,7 +169,6 @@ const parsedOtherSeries = computed(() => {
           />
         </div>
       </div>
-
     </div>
 
     <div class="full-width">
@@ -176,7 +183,9 @@ const parsedOtherSeries = computed(() => {
               {{ upcomingEvents }}
             </template>
             <template v-else>
-              <p class="empty-tab">There are no upcoming events in this series.</p>
+              <p class="empty-tab">
+                There are no upcoming events in this series.
+              </p>
             </template>
           </tab-item>
 
@@ -189,10 +198,11 @@ const parsedOtherSeries = computed(() => {
               {{ pastEvents }}
             </template>
             <template v-else>
-              <p class="empty-tab">There are no upcoming events in this series.</p>
+              <p class="empty-tab">
+                There are no upcoming events in this series.
+              </p>
             </template>
           </tab-item>
-
         </tab-list>
       </SectionWrapper>
     </div>
@@ -212,7 +222,7 @@ const parsedOtherSeries = computed(() => {
       <hr>
       <h2>Other Series Upcoming</h2>
       <pre>{{ otherSeriesUpcoming }}</pre>
-      <hr> 
+      <hr>
     </SectionWrapper> -->
 
     <!-- TODO: full-width column needed? -->
@@ -221,11 +231,10 @@ const parsedOtherSeries = computed(() => {
       :items="parsedOtherSeries"
       section-title="Explore other series"
     >
-      <template v-slot:top-right>
+      <template #top-right>
         <smart-link to="/series">
           View All Series <span style="font-size:1.5em;"> &#8250;</span>
         </smart-link>
-
       </template>
       <SectionTeaserCard :items="parsedOtherSeries" />
     </SectionWrapper>

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -281,19 +281,23 @@ onMounted(() => {
       v-if="parsedOtherSeries && parsedOtherSeries.length > 0"
       :items="parsedOtherSeries"
       section-title="Explore other series"
+      class="series-section-wrapper"
     >
       <template #top-right>
         <nuxt-link to="/series">
           View All Series <span style="font-size:1.5em;"> &#8250;</span>
         </nuxt-link>
       </template>
-      <SectionTeaserCard :items="parsedOtherSeries" />
+      <SectionTeaserCard
+        class="other-series-section"
+        :items="parsedOtherSeries"
+      />
     </SectionWrapper>
   </main>
 </template>
 
 <style lang="scss" scoped>
-// PAGE STYLES
+// GENERAL PAGE STYLES / DESKTOP
 .page-event-series-detail {
   position: relative;
 
@@ -348,6 +352,8 @@ onMounted(() => {
       display: none;
     }
 
+    // move these styles to a component so they can be reused & kept in sync
+    // with /events/[slug].vue
     .sidebar-column {
       min-width: 314px;
       width: 30%;
@@ -356,7 +362,7 @@ onMounted(() => {
       top: 0;
       right: 0;
       padding-top: var(--space-2xl);
-      padding-bottom: 20px;
+      padding-bottom: 40px;
 
       .sidebar-content-wrapper {
         position: sticky;
@@ -393,11 +399,19 @@ onMounted(() => {
     }
   }
 
-  /* makes all EventSeries same height */
-  :deep(.card) {
-    min-height: 350px;
+  .other-series-section {
+    &:has(> :last-child:nth-child(3)) {
+      /* if section has 3 elements */
+      justify-content: space-between;
+    }
+
+    /* makes all Other Series same height */
+    :deep(.card) {
+      min-height: 350px;
+    }
   }
 
+  // MEDIUM DEVICE STYLES
   @media (max-width: 1200px) {
 
     .one-column,
@@ -415,6 +429,7 @@ onMounted(() => {
     }
   }
 
+  // MOBILE STYLES
   @media #{$small} {
     .two-column {
       display: grid;
@@ -442,6 +457,13 @@ onMounted(() => {
         height: auto; // let content determine height on mobile
       }
     }
+  }
+}
+
+// TEMPORARY STYLES THAT SHOULD BE PART OF SECTIONWRAPPER
+.series-section-wrapper {
+  :deep(.section-header) {
+    margin-bottom: 28px;
   }
 }
 

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -82,7 +82,7 @@ const parsedUpcomingEvents = computed(() => {
   return upcomingEvents.value.map((item, index) => {
     return {
       ...item,
-      image: item.image[0]
+      image: item.image && item.image.length > 0 ? item.image[0] : null
     }
   })
 })
@@ -95,7 +95,7 @@ const parsedPastEvents = computed(() => {
   return pastEvents.value.map((item, index) => {
     return {
       ...item,
-      image: item.image[0]
+      image: item.image && item.image.length > 0 ? item.image[0] : null
     }
   })
 })
@@ -108,6 +108,8 @@ const parsedOtherSeries = computed(() => {
     return []
 
   let otherSeries = otherSeriesUpcoming.value.concat(otherSeriesOngoing.value)
+  // Remove current series from list
+  otherSeries = otherSeries.filter(item => !item.uri.includes(route.params.slug))
   // Get first 3 events
   otherSeries = otherSeries.slice(0, 3)
 
@@ -274,24 +276,6 @@ onMounted(() => {
         </TabList>
       </SectionWrapper>
     </div>
-
-    <SectionWrapper>
-      <!-- <h2>PAGE</h2>
-      <pre>{{ page }}</pre>
-      <hr>
-      <h2>UpcomingEvents</h2>
-      <pre>{{ upcomingEvents }}</pre>
-      <hr>
-      <h2>Past Events</h2>
-      <pre>{{ pastEvents }}</pre>
-      <hr>
-      <h2>Other Series Ongoing</h2>
-      <pre>{{ otherSeriesOngoing }}</pre>
-      <hr>
-      <h2>Other Series Upcoming</h2>
-      <pre>{{ otherSeriesUpcoming }}</pre>
-      <hr> -->
-    </SectionWrapper>
 
     <SectionWrapper
       v-if="parsedOtherSeries && parsedOtherSeries.length > 0"

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -172,13 +172,13 @@ onMounted(() => {
           <CardMeta
             category="Series"
             :title="page?.title"
-            :text="page?.richText"
+            :text="page?.eventDescription"
             :introduction="page?.ftvaEventIntroduction"
             :guest-speaker="page?.guestSpeaker"
           />
           <RichText
-            v-if="page?.eventDescription"
-            :rich-text-content="page?.eventDescription"
+            v-if="page?.richText"
+            :rich-text-content="page?.richText"
           />
         </SectionWrapper>
       </div>

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -2,7 +2,7 @@
 // COMPONENT RE-IMPORTS
 // TODO: remove when we have implemented component library as a module
 // https://nuxt.com/docs/guide/directory-structure/components#library-authors
-import { BlockEventDetail, BlockInfo, BlockTag, CardMeta, DividerWayFinder, FlexibleMediaGalleryNewLightbox, NavBreadcrumb, ResponsiveImage, RichText, SectionScreeningDetails, SectionTeaserCard, SectionWrapper, TabItem, TabList } from 'ucla-library-website-components'
+import { BlockCardThreeColumn, BlockEventDetail, BlockInfo, BlockTag, CardMeta, DividerWayFinder, FlexibleMediaGalleryNewLightbox, NavBreadcrumb, ResponsiveImage, RichText, SectionScreeningDetails, SectionTeaserCard, SectionTeaserList, SectionWrapper, TabItem, TabList } from 'ucla-library-website-components'
 
 // HELPERS
 import _get from 'lodash/get'
@@ -68,6 +68,34 @@ const parsedCarouselData = computed(() => {
     return {
       item: [{ ...rawItem.image[0], kind: 'image' }], // Carousels on this page are always images, no videos
       credit: rawItem?.creditText,
+    }
+  })
+})
+
+// Transform Data for Tabbed Section
+const parsedUpcomingEvents = computed(() => {
+  // fail gracefully if data does not exist (server-side)
+  if (!upcomingEvents.value)
+    return []
+
+  // Transform data
+  return upcomingEvents.value.map((item, index) => {
+    return {
+      ...item,
+      image: item.image[0]
+    }
+  })
+})
+const parsedPastEvents = computed(() => {
+  // fail gracefully if data does not exist (server-side)
+  if (!pastEvents.value)
+    return []
+
+  // Transform data
+  return pastEvents.value.map((item, index) => {
+    return {
+      ...item,
+      image: item.image[0]
     }
   })
 })
@@ -210,8 +238,13 @@ onMounted(() => {
             title="Upcoming Events"
             class="tab-content"
           >
-            <template v-if="upcomingEvents && upcomingEvents.length > 0">
-              {{ upcomingEvents }}
+            <template v-if="parsedUpcomingEvents && parsedUpcomingEvents.length > 0">
+              <SectionTeaserList
+                :items="parsedUpcomingEvents"
+                component-name="BlockCardThreeColumn"
+                n-shown="10"
+                class="tabbed-event-list"
+              />
             </template>
             <template v-else>
               <p class="empty-tab">
@@ -225,7 +258,12 @@ onMounted(() => {
             class="tab-content"
           >
             <template v-if="pastEvents && pastEvents.length > 0">
-              {{ pastEvents }}
+              <SectionTeaserList
+                :items="pastEvents"
+                component-name="BlockCardThreeColumn"
+                n-shown="10"
+                class="tabbed-event-list"
+              />
             </template>
             <template v-else>
               <p class="empty-tab">
@@ -261,9 +299,9 @@ onMounted(() => {
       section-title="Explore other series"
     >
       <template #top-right>
-        <smart-link to="/series">
+        <nuxt-link to="/series">
           View All Series <span style="font-size:1.5em;"> &#8250;</span>
-        </smart-link>
+        </nuxt-link>
       </template>
       <SectionTeaserCard :items="parsedOtherSeries" />
     </SectionWrapper>
@@ -360,12 +398,14 @@ onMounted(() => {
 
   .tab-content {
     min-height: 200px;
-    text-align: center;
+    border-radius: 15px;
+    overflow: hidden;
 
     .empty-tab {
       @include ftva-subtitle-1;
       color: var(--subtitle-grey);
       padding: 100px 0;
+      text-align: center;
     }
   }
 
@@ -416,6 +456,49 @@ onMounted(() => {
         margin: auto var(--unit-gutter);
         padding-top: 0px;
         height: auto; // let content determine height on mobile
+      }
+    }
+  }
+}
+
+// TEMPORARY STYLES THAT SHOULD BE PART OF BLOCKCARDTHREECOLUMN & SECTIONTEASERLIST
+.tabbed-event-list {
+  max-width: none;
+
+  :deep(.list-item) {
+    position: relative;
+    margin-bottom: var(--space-xl);
+    padding-bottom: 0;
+    border-bottom: transparent;
+
+    &:after {
+      content: '';
+      width: 95%;
+      position: absolute;
+      left: 2.5%;
+      bottom: -22px;
+      border-bottom: 1px solid #e7edf2;
+    }
+
+    .day-month-date,
+    .meta {
+      background: white;
+    }
+
+    &:last-child {
+      border: 0;
+      margin-bottom: 0;
+      padding-bottom: 0;
+      border-radius: 0 0 35px 25px;
+    }
+
+    // Breakpoints
+    @media #{$medium} {
+      --divider-color: none;
+      background-color: transparent;
+
+      &::after {
+        display: none;
       }
     }
   }

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -110,12 +110,28 @@ const parsedCarouselData = computed(() => {
           />
         </SectionWrapper>
       </div>
+      <div class="sidebar-column">
+        <div class="sidebar-content-wrapper">
+          <BlockEventDetail
+            data-test="event-details"
+            :start-date="page?.startDateWithTime"
+            :time="page?.startDateWithTime"
+            :locations="page?.location"
+          />
+          <BlockInfo
+            v-if="page?.ftvaTicketInformation && page?.ftvaTicketInformation.length > 0"
+            data-test="ticket-info"
+            :ftva-ticket-information="page?.ftvaTicketInformation"
+          />
+        </div>
+      </div>
+
     </div>
 
     <!-- <div class="full-width">
       <SectionWrapper
         v-if="parsedFtvaEventSeries && parsedFtvaEventSeries.length > 0"
-        section-title="Upcoming events in this series"
+        section-title="Explore other series"
         theme="paleblue"
       >
         <SectionTeaserCard
@@ -142,20 +158,18 @@ const parsedCarouselData = computed(() => {
       <pre>{{ otherSeriesUpcoming }}</pre>
       <hr>
     </SectionWrapper>
+    <SectionWrapper
+      v-if="parsedFtvaEventSeries && parsedFtvaEventSeries.length > 0"
+      :items="parsedFtvaEventSeries"
+      section-title="Explore other series"
+      theme="paleblue"
+    >
+      <SectionTeaserCard :items="parsedFtvaEventSeries" />
+    </SectionWrapper>
   </main>
 </template>
 
-<style
-  lang="scss"
-  scoped
->
-// VARS - TO DO move to global? reference tokens?
-// WIDTH, HEIGHT, SPACING
-$max-width: 1160px;
-$banner-height: 520px;
-// COLORS
-$pale-blue: #E7EDF2;
-
+<style lang="scss" scoped>
 // PAGE STYLES
 .page-event-series-detail {
   position: relative;
@@ -163,7 +177,7 @@ $pale-blue: #E7EDF2;
   &:before {
     content: '';
     position: absolute;
-    background-color: $pale-blue;
+    background-color: var(--pale-blue);
     aspect-ratio: 1440 / 520;
     max-height: 518px; //prevent overflow on large screens
     min-height: 225px; //prevent too much shrinking on small screens
@@ -173,7 +187,7 @@ $pale-blue: #E7EDF2;
 
   .one-column {
     width: 100%;
-    max-width: $max-width;
+    max-width: var(--max-width);
     margin: 0 auto;
 
     :deep(.nav-breadcrumb) {
@@ -185,7 +199,7 @@ $pale-blue: #E7EDF2;
   .two-column {
     position: relative;
     width: 100%;
-    max-width: $max-width;
+    max-width: var(--max-width);
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
@@ -233,11 +247,11 @@ $pale-blue: #E7EDF2;
 
   .full-width {
     width: 100%;
-    background-color: $pale-blue;
+    background-color: var(--pale-blue);
     margin: 0 auto;
 
     .section-wrapper.theme-paleblue {
-      background-color: $pale-blue;
+      background-color: var(--pale-blue);
     }
   }
 

--- a/pages/series/index.vue
+++ b/pages/series/index.vue
@@ -10,7 +10,7 @@ import FTVAEventSeriesList from '../gql/queries/FTVAEventSeriesList.gql'
 
 const { $graphql } = useNuxtApp()
 
-const { data, error } = await useAsyncData('event-list', async () => {
+const { data, error } = await useAsyncData('series-list', async () => {
   const data = await $graphql.default.request(FTVAEventSeriesList)
   return data
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ devDependencies:
     specifier: ^5.22.0
     version: 5.22.0
   ucla-library-website-components:
-    specifier: 3.15.1
-    version: 3.15.1(typescript@5.4.5)(vue@3.4.31)
+    specifier: 3.16.0
+    version: 3.16.0(typescript@5.4.5)(vue@3.4.31)
 
 packages:
 
@@ -9988,8 +9988,8 @@ packages:
     resolution: {integrity: sha512-HudkrR/TMd5FTV1VGqOrYLg4bsDgb8kgml6rtDF3NgS9vf0hfQyVipxjbEHlfvuPHtQ7RZcn6ftdJHi92JqfSw==}
     dev: true
 
-  /ucla-library-website-components@3.15.1(typescript@5.4.5)(vue@3.4.31):
-    resolution: {integrity: sha512-a5jyKKXxlZ1VQhQwWtPuEEL6Aspvb0d5MrqKal7CHPXT5AfnO+NUziGiR7Jhf7PAQdPy6HutIthM3GCi8hJusg==}
+  /ucla-library-website-components@3.16.0(typescript@5.4.5)(vue@3.4.31):
+    resolution: {integrity: sha512-2I3N2nEn14y9f/sQXZLAA9zW6r6fVpVYBqI7uFQAD9Fm7fylsyLtJ0LEL8FACMxOgDImhzErvknj+BORqA8kHw==}
     peerDependencies:
       vue: ^3.4.29
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ devDependencies:
     specifier: ^5.22.0
     version: 5.22.0
   ucla-library-website-components:
-    specifier: 3.12.0
-    version: 3.12.0(typescript@5.4.5)(vue@3.4.31)
+    specifier: 3.15.1
+    version: 3.15.1(typescript@5.4.5)(vue@3.4.31)
 
 packages:
 
@@ -1149,9 +1149,6 @@ packages:
     resolution: {integrity: sha512-7nhBTRkTG0mD+7r7JvNalJz++YwszZk0oP1HIY6fCgz6wNKxT6LuiXCqdPrZmNPe/WbPIKuqxGZN5s+i6NZqow==}
     peerDependencies:
       vue: '>= 3.2.0 < 4.0.0'
-    peerDependenciesMeta:
-      vue-router:
-        optional: true
     dependencies:
       '@gtm-support/core': 2.3.1
       vue: 3.4.31(typescript@5.4.5)
@@ -9991,8 +9988,8 @@ packages:
     resolution: {integrity: sha512-HudkrR/TMd5FTV1VGqOrYLg4bsDgb8kgml6rtDF3NgS9vf0hfQyVipxjbEHlfvuPHtQ7RZcn6ftdJHi92JqfSw==}
     dev: true
 
-  /ucla-library-website-components@3.12.0(typescript@5.4.5)(vue@3.4.31):
-    resolution: {integrity: sha512-IL8RzvfWrHRV6qFeXRJ/Z/Lv0OsbfgxoOetZlzo/La6hr5rVLQ1ZsAdOU+a5niFRrRSRoFvkVMFy8b3o9fCCFQ==}
+  /ucla-library-website-components@3.15.1(typescript@5.4.5)(vue@3.4.31):
+    resolution: {integrity: sha512-a5jyKKXxlZ1VQhQwWtPuEEL6Aspvb0d5MrqKal7CHPXT5AfnO+NUziGiR7Jhf7PAQdPy6HutIthM3GCi8hJusg==}
     peerDependencies:
       vue: ^3.4.29
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ devDependencies:
     specifier: ^5.22.0
     version: 5.22.0
   ucla-library-website-components:
-    specifier: 3.17.1
-    version: 3.17.1(typescript@5.4.5)(vue@3.4.31)
+    specifier: 3.18.0
+    version: 3.18.0(typescript@5.4.5)(vue@3.4.31)
 
 packages:
 
@@ -9988,8 +9988,8 @@ packages:
     resolution: {integrity: sha512-HudkrR/TMd5FTV1VGqOrYLg4bsDgb8kgml6rtDF3NgS9vf0hfQyVipxjbEHlfvuPHtQ7RZcn6ftdJHi92JqfSw==}
     dev: true
 
-  /ucla-library-website-components@3.17.1(typescript@5.4.5)(vue@3.4.31):
-    resolution: {integrity: sha512-bL9/SdTvn3CIgM2AW+ivYKatumHhLGeRVyxbw4MHqtAYXHYDgPYl0A2n2itdxmmmZxlOsrk4gDAujKhWVVkdFw==}
+  /ucla-library-website-components@3.18.0(typescript@5.4.5)(vue@3.4.31):
+    resolution: {integrity: sha512-FwVpa39MetUHduD3/4wtR/a7Xl2AuTQxFudN4hHuo61JaOKtzaTuFeWuoFrPIzQLXmI15V1Lk9yKxk9zl5qPaQ==}
     peerDependencies:
       vue: ^3.4.29
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ devDependencies:
     specifier: ^5.22.0
     version: 5.22.0
   ucla-library-website-components:
-    specifier: 3.16.0
-    version: 3.16.0(typescript@5.4.5)(vue@3.4.31)
+    specifier: 3.17.1
+    version: 3.17.1(typescript@5.4.5)(vue@3.4.31)
 
 packages:
 
@@ -9988,8 +9988,8 @@ packages:
     resolution: {integrity: sha512-HudkrR/TMd5FTV1VGqOrYLg4bsDgb8kgml6rtDF3NgS9vf0hfQyVipxjbEHlfvuPHtQ7RZcn6ftdJHi92JqfSw==}
     dev: true
 
-  /ucla-library-website-components@3.16.0(typescript@5.4.5)(vue@3.4.31):
-    resolution: {integrity: sha512-2I3N2nEn14y9f/sQXZLAA9zW6r6fVpVYBqI7uFQAD9Fm7fylsyLtJ0LEL8FACMxOgDImhzErvknj+BORqA8kHw==}
+  /ucla-library-website-components@3.17.1(typescript@5.4.5)(vue@3.4.31):
+    resolution: {integrity: sha512-bL9/SdTvn3CIgM2AW+ivYKatumHhLGeRVyxbw4MHqtAYXHYDgPYl0A2n2itdxmmmZxlOsrk4gDAujKhWVVkdFw==}
     peerDependencies:
       vue: ^3.4.29
     dependencies:


### PR DESCRIPTION
Connected to [APPS-2910](https://jira.library.ucla.edu/browse/APPS-2910)

**Page/Pages Created/updated:** [slug].vue 

**Notes:**

Styles:
For the first page I added most styles directly to the page, including some global variables.
Because we are reusing a lot of these styles across pages, I have moved reused styles to global.scss to prevent duplication and keep things DRY

MOBILE:
The mockups for this page show complex behavior for the sidebar content (the previously sticky sidebar needs to split into 2 distinct content blocks and slot into 2 different areas in the column). This work is not 100% done, and will be continued in this ticket https://uclalibrary.atlassian.net/browse/APPS-2946

BLOCKCARDTHREECOLUMN: 
Fixed in this [commit](https://github.com/UCLALibrary/ftva-website/nuxt/pull/39/commits/f3598b35c03a584924e61d4d12f0b064f0ae52d9)
~Currently the links do not work, I believe this is because of the way card-meta implements links using formatLinkTarget, this will likely need to be fixed next week as it cannot be fixed from the page side.~

**Time Report:**

This took me 10-12 hours to build this.

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   [ ] I completed any required mobile breakpoint styling
-   [X] I completed any required hover state styling
-   [X] I included a working spec file
-   [X] I added notes above about how long it took to build this component
-   [ ] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-2910]: https://uclalibrary.atlassian.net/browse/APPS-2910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ