### PR TITLE
feat: APPS-2955 remaining components 

### DIFF
--- a/cypress/e2e/blogArticlePage.cy.js
+++ b/cypress/e2e/blogArticlePage.cy.js
@@ -1,0 +1,8 @@
+describe('Blog Article Page', () => {
+  it('Visits a Blog Article Page', () => {
+    cy.visit('/blog/test-tom-reeds-for-members-only-black-perspectives-on-local-l-a-tv')
+    cy.getByData('breadcrumb').should('be.visible')
+    cy.getByData('recent-posts').should('be.visible')
+    cy.percySnapshot('blogarticlepage', { widths: [768, 992, 1200] })
+  })
+})

--- a/gql/queries/FTVAArticleDetail.gql
+++ b/gql/queries/FTVAArticleDetail.gql
@@ -40,7 +40,8 @@ query FTVAArticleDetail($slug: [String!]) {
     ...AllFtvaFpb
   }
   # SectionTeaserCard (Recent posts)
-  ftvaRecentPosts: entries( section: "ftvaArticle", limit: 3, orderBy: "postDate ASC") {
+  # page only displays 3 but we query 4 in case the list includes the current article
+  ftvaRecentPosts: entries( section: "ftvaArticle", limit: 4, orderBy: "postDate ASC") {
     id
     title
     to: slug

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
 		"nuxt-graphql-request": "^7.0.5",
 		"sass": "^1.66.1",
 		"ucla-library-design-tokens": "^5.22.0",
-		"ucla-library-website-components": "3.22.1"
+		"ucla-library-website-components": "3.23.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
 		"nuxt-graphql-request": "^7.0.5",
 		"sass": "^1.66.1",
 		"ucla-library-design-tokens": "^5.22.0",
-		"ucla-library-website-components": "3.23.0"
+		"ucla-library-website-components": "3.26.0"
 	}
 }

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -99,6 +99,14 @@ const parsedArticleCategories = computed(() => {
   return ''
 })
 
+// Get the Contributor data if it exists, otherwise return nothing
+const parsedByline = computed(() => {
+  if ((page.value.contributors && page.value.contributors[0]) && page.value.contributors[0].contributor) {
+    return page.value.contributors[0].contributor
+  }
+  return ''
+})
+
 // Recent Posts: Filter out the current post and then return the first 3 max
 const parsedRecentPosts = computed(() => {
   // fail gracefully if no recent posts
@@ -166,7 +174,7 @@ const parsedRecentPosts = computed(() => {
           data-test="text-block"
           :category="parsedArticleCategories"
           :title="page?.title"
-          :byline-one="page?.contributors[0].contributor"
+          :byline-one="parsedByline"
           :date-created="page?.postDate"
           :text="page?.aboutTheAuthor"
           section-handle="ftvaArticle"
@@ -260,6 +268,11 @@ const parsedRecentPosts = computed(() => {
       }
 
     }
+  }
+
+  // if there is no author content, hide the 'about the author' heading
+  :deep(.heading-about-author:not(:has(+.rich-text))) {
+    display: none;
   }
 
   @media (max-width: 1200px) {

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -104,7 +104,16 @@ const parsedRecentPosts = computed(() => {
   // fail gracefully if no recent posts
   if (!ftvaRecentPosts.value)
     return []
-  return ftvaRecentPosts.value.filter(item => !item.to.includes(route.params.slug)).slice(0, 3)
+
+  // Transform data
+  const recentPostsWImage = ftvaRecentPosts.value.map((item, index) => {
+    console.log('item', item.imageCarousel[0].image[0])
+    return {
+      ...item,
+      image: item.imageCarousel && item.imageCarousel.length > 0 ? item.imageCarousel[0].image[0] : null,
+    }
+  })
+  return recentPostsWImage.filter(item => !item.to.includes(route.params.slug)).slice(0, 3)
 })
 </script>
 

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -3,7 +3,7 @@
 // TODO: remove when we have implemented component library as a module
 // https://nuxt.com/docs/guide/directory-structure/components#library-authors
 import {
-  BlockTag, CardMeta, DividerWayFinder, FlexibleMediaGalleryNewLightbox, FlexibleBlocks, NavBreadcrumb, ResponsiveImage, RichText, SectionTeaserCard, SectionWrapper, TwoColLayoutWStickySideBar
+  BlockTag, ButtonDropdown, CardMeta, DividerWayFinder, FlexibleMediaGalleryNewLightbox, FlexibleBlocks, NavBreadcrumb, ResponsiveImage, RichText, SectionTeaserCard, SectionWrapper, TwoColLayoutWStickySideBar
 } from 'ucla-library-website-components'
 
 // HELPERS
@@ -15,6 +15,34 @@ import FTVAArticleDetail from '../gql/queries/FTVAArticleDetail.gql'
 const { $graphql } = useNuxtApp()
 
 const route = useRoute()
+
+// TODO should this data be changed to reflect current page URL? Moved somewhere else?
+const socialList = {
+  buttonTitle: 'Share',
+  hasIcon: true,
+  dropdownList: [
+    {
+      dropdownItemTitle: 'Copy Link',
+      dropdownItemUrl: '',
+      iconName: 'svg-icon-ftva-social-link',
+    },
+    {
+      dropdownItemTitle: 'Email',
+      dropdownItemUrl: '',
+      iconName: 'svg-icon-ftva-social-email',
+    },
+    {
+      dropdownItemTitle: 'Facebook',
+      dropdownItemUrl: 'https://www.facebook.com/sharer/sharer.php?u=',
+      iconName: 'svg-icon-ftva-social-facebook',
+    },
+    {
+      dropdownItemTitle: 'X',
+      dropdownItemUrl: 'https://twitter.com/share?url=',
+      iconName: 'svg-icon-ftva-social-x',
+    },
+  ],
+}
 
 // DATA
 const { data, error } = await useAsyncData(`blog-${route.params.slug}`, async () => {
@@ -134,7 +162,15 @@ const parsedRecentPosts = computed(() => {
           :byline-one="page?.contributors[0].contributor"
           :text="page?.aboutTheAuthor"
           section-handle="ftvaArticle"
-        />
+        >
+          <template #sharebutton>
+            <ButtonDropdown
+              button-title="Share"
+              :has-icon="true"
+              :dropdown-list="socialList.dropdownList"
+            />
+          </template>
+        </CardMeta>
         <DividerWayFinder class="remove-top-margin" />
         <FlexibleBlocks
           class="flexible-content"

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -246,6 +246,14 @@ const parsedRecentPosts = computed(() => {
     display: none;
   }
 
+  // remove max-width from rich-text inside flexible-blocks for ftva
+  :deep(.flexible-block) {
+    .rich-text {
+      max-width: none;
+      padding-right: 0px;
+    }
+  }
+
   @media (max-width: 1200px) {
 
     .one-column,

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -11,38 +11,11 @@ import _get from 'lodash/get'
 
 // GQL
 import FTVAArticleDetail from '../gql/queries/FTVAArticleDetail.gql'
+import socialList from '~/utils/socialList'
 
 const { $graphql } = useNuxtApp()
 
 const route = useRoute()
-
-// TODO should this data be changed to reflect current page URL? Moved somewhere else?
-const socialList = {
-  buttonTitle: 'Share',
-  hasIcon: true,
-  dropdownList: [
-    {
-      dropdownItemTitle: 'Copy Link',
-      dropdownItemUrl: '',
-      iconName: 'svg-icon-ftva-social-link',
-    },
-    {
-      dropdownItemTitle: 'Email',
-      dropdownItemUrl: '',
-      iconName: 'svg-icon-ftva-social-email',
-    },
-    {
-      dropdownItemTitle: 'Facebook',
-      dropdownItemUrl: 'https://www.facebook.com/sharer/sharer.php?u=',
-      iconName: 'svg-icon-ftva-social-facebook',
-    },
-    {
-      dropdownItemTitle: 'X',
-      dropdownItemUrl: 'https://twitter.com/share?url=',
-      iconName: 'svg-icon-ftva-social-x',
-    },
-  ],
-}
 
 // DATA
 const { data, error } = await useAsyncData(`blog-${route.params.slug}`, async () => {
@@ -85,8 +58,6 @@ const parsedCarouselData = computed(() => {
     return {
       item: [{ ...rawItem.image[0], kind: 'image' }], // Carousels on this page are always images, no videos
       credit: rawItem?.creditText,
-      // captionTitle: 'dfdsfs', // TODO do we need these? test without
-      // captionText: 'dfsdfsd',
     }
   })
 })

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -154,12 +154,12 @@ const parsedRecentPosts = computed(() => {
 
     <TwoColLayoutWStickySideBar>
       <template #primaryTop>
-        <!-- TODO           :dateCreated="postDate"-->
         <CardMeta
           data-test="text-block"
           :category="parsedArticleCategories"
           :title="page?.title"
           :byline-one="page?.contributors[0].contributor"
+          :dateCreated="page?.postDate"
           :text="page?.aboutTheAuthor"
           section-handle="ftvaArticle"
         >

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -102,12 +102,11 @@ const parsedArticleCategories = computed(() => {
 // Recent Posts: Filter out the current post and then return the first 3 max
 const parsedRecentPosts = computed(() => {
   // fail gracefully if no recent posts
-  if (!ftvaRecentPosts.value)
+  if (!ftvaRecentPosts.value || !route.params.slug)
     return []
 
   // Transform data
   const recentPostsWImage = ftvaRecentPosts.value.map((item, index) => {
-    console.log('item', item.imageCarousel[0].image[0])
     return {
       ...item,
       image: item.imageCarousel && item.imageCarousel.length > 0 ? item.imageCarousel[0].image[0] : null,
@@ -194,6 +193,11 @@ const parsedRecentPosts = computed(() => {
       section-title="Read our most recent posts"
       theme="paleblue"
     >
+      <template #top-right>
+        <nuxt-link to="/series">
+          View All Series <span style="font-size:1.5em;"> &#8250;</span>
+        </nuxt-link>
+      </template>
       <SectionTeaserCard
         v-if="parsedRecentPosts && parsedRecentPosts.length > 0"
         data-test="recent-posts"

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -159,7 +159,7 @@ const parsedRecentPosts = computed(() => {
           :category="parsedArticleCategories"
           :title="page?.title"
           :byline-one="page?.contributors[0].contributor"
-          :dateCreated="page?.postDate"
+          :date-created="page?.postDate"
           :text="page?.aboutTheAuthor"
           section-handle="ftvaArticle"
         >
@@ -177,6 +177,7 @@ const parsedRecentPosts = computed(() => {
           :blocks="page.blocks"
         />
       </template>
+      <template #sidebarTop />
     </TwoColLayoutWStickySideBar>
 
     <SectionWrapper
@@ -231,43 +232,52 @@ const parsedRecentPosts = computed(() => {
     .primary-column {
       width: 78%; // override default 67% for article pages only
 
-      .section-wrapper {
+      .primary-section-wrapper {
         padding-left: 0px;
+        margin-top: var(--space-2xl);
+      }
+
+      .section-wrapper {
         margin-top: var(--space-2xl);
       }
 
       .remove-top-margin {
         margin-top: 0px;
+        padding-top: var(--space-l);
       }
 
     }
   }
 
-  .flexible-content {
-    .rich-text {
-      max-width: none;
-    }
-  }
-
   @media (max-width: 1200px) {
 
-    .one-column {
+    .one-column,
+    .two-column {
       padding-left: var(--unit-gutter);
       padding-right: var(--unit-gutter);
     }
 
     :deep(.two-column) {
-      padding-left: var(--unit-gutter);
+      display: flex;
 
       // increase column percentage to 100 at 1200px
       // only for article pages, since there is no sidebar content
       .primary-column {
         width: 100%;
 
-        .section-wrapper {
+        .primary-section-wrapper {
           padding-right: 0px;
         }
+      }
+    }
+  }
 
+  @media #{$small} {
+    .two-column {
+      display: flex;
+
+      .remove-top-margin {
+        margin-top: var(--space-2xl); //re add space as padding for mobile
       }
     }
   }

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -53,8 +53,8 @@ const parsedCarouselData = computed(() => {
     return {
       item: [{ ...rawItem.image[0], kind: 'image' }], // Carousels on this page are always images, no videos
       credit: rawItem?.creditText,
-      captionTitle: 'dfdsfs', // TODO do we need these? test without
-      captionText: 'dfsdfsd',
+      // captionTitle: 'dfdsfs', // TODO do we need these? test without
+      // captionText: 'dfsdfsd',
     }
   })
 })
@@ -240,10 +240,7 @@ const parsedFTVAEventScreeningDetails = computed(() => {
   </main>
 </template>
 
-<style
-  lang="scss"
-  scoped
->
+<style lang="scss" scoped>
 // PAGE STYLES
 .page-event-detail {
   position: relative;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9988,13 +9988,8 @@ packages:
     resolution: {integrity: sha512-HudkrR/TMd5FTV1VGqOrYLg4bsDgb8kgml6rtDF3NgS9vf0hfQyVipxjbEHlfvuPHtQ7RZcn6ftdJHi92JqfSw==}
     dev: true
 
-<<<<<<< Updated upstream
-  /ucla-library-website-components@3.22.1(typescript@5.4.5)(vue@3.4.31):
-    resolution: {integrity: sha512-urlbfKBTtgMhBQkq5pfob3YvF84RMGii3fGM3kak7AqtGKn39m8RNGGyla6ZPAadH2xVONokV7EOZD4kEfklqw==}
-=======
   /ucla-library-website-components@3.23.0(typescript@5.4.5)(vue@3.4.31):
     resolution: {integrity: sha512-8Z2k4WnKygap1KWGjfIQzNlpfAWK/apF15I+0NHgy4CSNyYQzFBIV8Cz+HuWNUyYWpkE482ZTV9V+AhPyIaFBw==}
->>>>>>> Stashed changes
     peerDependencies:
       vue: ^3.4.29
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ devDependencies:
     specifier: ^5.22.0
     version: 5.22.0
   ucla-library-website-components:
-    specifier: 3.23.0
-    version: 3.23.0(typescript@5.4.5)(vue@3.4.31)
+    specifier: 3.26.0
+    version: 3.26.0(typescript@5.4.5)(vue@3.4.31)
 
 packages:
 
@@ -9988,8 +9988,8 @@ packages:
     resolution: {integrity: sha512-HudkrR/TMd5FTV1VGqOrYLg4bsDgb8kgml6rtDF3NgS9vf0hfQyVipxjbEHlfvuPHtQ7RZcn6ftdJHi92JqfSw==}
     dev: true
 
-  /ucla-library-website-components@3.23.0(typescript@5.4.5)(vue@3.4.31):
-    resolution: {integrity: sha512-8Z2k4WnKygap1KWGjfIQzNlpfAWK/apF15I+0NHgy4CSNyYQzFBIV8Cz+HuWNUyYWpkE482ZTV9V+AhPyIaFBw==}
+  /ucla-library-website-components@3.26.0(typescript@5.4.5)(vue@3.4.31):
+    resolution: {integrity: sha512-g56cx6ntsl4dROSjrEGCa+mA++mXRIX3dUrVsCy0AL9EauXk9bUZGWnK0fKg3qXo7+UFICZztqcN5wDsapEB3w==}
     peerDependencies:
       vue: ^3.4.29
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ devDependencies:
     specifier: ^5.22.0
     version: 5.22.0
   ucla-library-website-components:
-    specifier: 3.22.1
-    version: 3.22.1(typescript@5.4.5)(vue@3.4.31)
+    specifier: 3.23.0
+    version: 3.23.0(typescript@5.4.5)(vue@3.4.31)
 
 packages:
 
@@ -1149,9 +1149,6 @@ packages:
     resolution: {integrity: sha512-7nhBTRkTG0mD+7r7JvNalJz++YwszZk0oP1HIY6fCgz6wNKxT6LuiXCqdPrZmNPe/WbPIKuqxGZN5s+i6NZqow==}
     peerDependencies:
       vue: '>= 3.2.0 < 4.0.0'
-    peerDependenciesMeta:
-      vue-router:
-        optional: true
     dependencies:
       '@gtm-support/core': 2.3.1
       vue: 3.4.31(typescript@5.4.5)
@@ -9991,8 +9988,13 @@ packages:
     resolution: {integrity: sha512-HudkrR/TMd5FTV1VGqOrYLg4bsDgb8kgml6rtDF3NgS9vf0hfQyVipxjbEHlfvuPHtQ7RZcn6ftdJHi92JqfSw==}
     dev: true
 
+<<<<<<< Updated upstream
   /ucla-library-website-components@3.22.1(typescript@5.4.5)(vue@3.4.31):
     resolution: {integrity: sha512-urlbfKBTtgMhBQkq5pfob3YvF84RMGii3fGM3kak7AqtGKn39m8RNGGyla6ZPAadH2xVONokV7EOZD4kEfklqw==}
+=======
+  /ucla-library-website-components@3.23.0(typescript@5.4.5)(vue@3.4.31):
+    resolution: {integrity: sha512-8Z2k4WnKygap1KWGjfIQzNlpfAWK/apF15I+0NHgy4CSNyYQzFBIV8Cz+HuWNUyYWpkE482ZTV9V+AhPyIaFBw==}
+>>>>>>> Stashed changes
     peerDependencies:
       vue: ^3.4.29
     dependencies:

--- a/utils/socialList.js
+++ b/utils/socialList.js
@@ -1,0 +1,28 @@
+export const socialList = {
+  buttonTitle: 'Share',
+  hasIcon: true,
+  dropdownList: [
+    {
+      dropdownItemTitle: 'Copy Link',
+      dropdownItemUrl: '',
+      iconName: 'svg-icon-ftva-social-link',
+    },
+    {
+      dropdownItemTitle: 'Email',
+      dropdownItemUrl: '',
+      iconName: 'svg-icon-ftva-social-email',
+    },
+    {
+      dropdownItemTitle: 'Facebook',
+      dropdownItemUrl: 'https://www.facebook.com/sharer/sharer.php?u=',
+      iconName: 'svg-icon-ftva-social-facebook',
+    },
+    {
+      dropdownItemTitle: 'X',
+      dropdownItemUrl: 'https://twitter.com/share?url=',
+      iconName: 'svg-icon-ftva-social-x',
+    },
+  ],
+}
+
+export default socialList


### PR DESCRIPTION
Connected to [APPS-2955](https://jira.library.ucla.edu/browse/APPS-2955)

**Page/Pages Created/updated:** /blog/[slug].vue from APPS-2955

**Notes:**

- Updated package to latest components
- Added cypress test for blog page
- Added sidebar to blog page
- Added Share Dropdown Button and new CardMeta dateCreated data
- Added a computed method to parse images from recentPosts data
- Slight edit to FTVAArticleDetail.gql to return 4 items instead of 3, as well as computed method to parse current article out of data
- Slight edit to categories logic to reduce # of lines (this is a matter of opinion and we can revert this if we want the longer -but possibly more readable- version)
- Tested and removed some junk data from carousel (also removed same junk data from /events/[slug].vue)
- Tweaked column widths to match this figma file https://www.figma.com/design/L8e1czKo8a8px368ayyPZ4/%5BFTVA%5D-Final-Design-with-Annotations?node-id=28-3222&node-type=canvas&t=LQoUm8iQxVU7xSqX-0
- Since many flexible blocks are not designed for small screens, we make the primary column 100% of the layout width when we get to 1200px
- Setup Recent Posts section with SectionTeaserCard & 'View All Series >' link
- Verified dates were showing in SectionTeaserCard after latest package update

**Time Report:**

6ish hours so far off and on

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   [X] I completed any required mobile breakpoint styling
-   [X] I completed any required hover state styling
-   [X] I included a working spec file
-   [X] I added notes above about how long it took to build this component
-   [ ] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-2955]: https://uclalibrary.atlassian.net/browse/APPS-2955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ