### PR TITLE
fix: APPS-2970 dateTimes incorrect in ftva

### DIFF
--- a/gql/queries/EventDetail.gql
+++ b/gql/queries/EventDetail.gql
@@ -31,8 +31,8 @@ query FTVADetail($slug: [String!]) {
 
 
       # BlockEventDetail
-      startDate: startDateWithTime @formatDateTime(format: "Y-m-d", timezone: "America/Los_Angeles")
-      startTime: startDateWithTime @formatDateTime(format: "TH:i:s", timezone: "America/Los_Angeles")
+      startDate: startDateWithTime @formatDateTime(format: "Y-m-d\\TH:i", timezone: "America/Los_Angeles")
+      startTime: startDateWithTime @formatDateTime(format: "Y-m-d\\TH:i", timezone: "America/Los_Angeles")
       location {
         title
         uri

--- a/gql/queries/FTVAEventDetail.gql
+++ b/gql/queries/FTVAEventDetail.gql
@@ -52,9 +52,13 @@ query FTVAEventDetail($slug: [String!]) {
 
     # SIDEBAR
     # BlockEventDetail
-    startDateWithTime
-    startDate: startDateWithTime @formatDateTime(format: "Y-m-d", timezone: "America/Los_Angeles")
-    startTime: startDateWithTime @formatDateTime(format: "TH:i:s", timezone: "America/Los_Angeles")
+    startDateWithTime 
+      @formatDateTime(
+        format: "Y-m-d\\TH:i"
+        timezone: "America/Los_Angeles"
+      )
+    startDate: startDateWithTime @formatDateTime(format: "Y-m-d\\TH:i:s", timezone: "America/Los_Angeles")
+    startTime: startDateWithTime @formatDateTime(format: "Y-m-d\\TH:i:s", timezone: "America/Los_Angeles")
     location {
       title
       campusMapId
@@ -89,8 +93,8 @@ query FTVAEventDetail($slug: [String!]) {
           id
           to: slug
           title: eventTitle
-          startDate: startDateWithTime @formatDateTime(format: "Y-m-d", timezone: "America/Los_Angeles")
-          startTime: startDateWithTime @formatDateTime(format: "TH:i:s", timezone: "America/Los_Angeles")
+          startDate: startDateWithTime @formatDateTime(format: "Y-m-d\\TH:i:s", timezone: "America/Los_Angeles")
+          startTime: startDateWithTime @formatDateTime(format: "Y-m-d\\TH:i:s", timezone: "America/Los_Angeles")
           image: ftvaImage {
             ...Image
           }

--- a/gql/queries/FTVAEventList.gql
+++ b/gql/queries/FTVAEventList.gql
@@ -10,8 +10,12 @@ query FTVAEventList {
     #  ...Image
     # }
     startDateWithTime
-    startDate: startDateWithTime @formatDateTime(format: "Y-m-d", timezone: "America/Los_Angeles")
-    startTime: startDateWithTime @formatDateTime(format: "TH:i:s", timezone: "America/Los_Angeles")
+      @formatDateTime(
+        format: "Y-m-d\\TH:i"
+        timezone: "America/Los_Angeles"
+      )
+    startDate: startDateWithTime @formatDateTime(format: "Y-m-d\\TH:i:s", timezone: "America/Los_Angeles")
+    startTime: startDateWithTime @formatDateTime(format: "Y-m-d\\TH:i:s", timezone: "America/Los_Angeles")
 
     ftvaEventFilters {
       title

--- a/gql/queries/FTVAEventSeriesDetail.gql
+++ b/gql/queries/FTVAEventSeriesDetail.gql
@@ -15,8 +15,16 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
     ftvaEventIntroduction
     eventDescription
     acknowledgement: richText
-    startDate
+    startDate 
+      @formatDateTime(
+        format: "Y-m-d\\TH:i"
+        timezone: "America/Los_Angeles"
+      )
     endDate
+      @formatDateTime(
+      format: "Y-m-d\\TH:i"
+      timezone: "America/Los_Angeles"
+    )
     ongoing
     location {
       title
@@ -37,7 +45,7 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
     ftvaEvent {
       uri
       eventTitle
-      startDateWithTime
+      startDateWithTime @formatDateTime(format: "Y-m-d\\TH:i", timezone: "America/Los_Angeles")
       ftvaImage {
         ...Image
       }
@@ -50,9 +58,13 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
       to: uri
       sectionHandle
       title: eventTitle
-      startDateWithTime
-      startDate: startDateWithTime @formatDateTime(format: "Y-m-d", timezone: "America/Los_Angeles")
-    	startTime: startDateWithTime @formatDateTime(format: "TH:i:s", timezone: "America/Los_Angeles")
+      startDateWithTime 
+        @formatDateTime(
+          format: "Y-m-d\\TH:i"
+          timezone: "America/Los_Angeles"
+        )
+      startDate: startDateWithTime @formatDateTime(format: "Y-m-d\\TH:i", timezone: "America/Los_Angeles")
+    	startTime: startDateWithTime @formatDateTime(format: "Y-m-d\\TH:i", timezone: "America/Los_Angeles")
       image: ftvaImage {
         ...Image
       }
@@ -67,8 +79,8 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
                     format: "Y-m-d\\TH:i"
                     timezone: "America/Los_Angeles"
                 )
-    startDate: startDateWithTime @formatDateTime(format: "Y-m-d", timezone: "America/Los_Angeles")
-    startTime: startDateWithTime @formatDateTime(format: "TH:i:s", timezone: "America/Los_Angeles")
+    startDate: startDateWithTime @formatDateTime(format: "Y-m-d\\TH:i", timezone: "America/Los_Angeles")
+    startTime: startDateWithTime @formatDateTime(format: "Y-m-d\\TH:i", timezone: "America/Los_Angeles")
     image: ftvaImage {
       ...Image
     }
@@ -76,37 +88,12 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
       title
     }
   }
-  # CAN BE REMOVED ONCE NEW ONES ARE WORKING
-  # upcomingEvents: entries(section: "ftvaEvent", relatedToEntries: { section: "ftvaEventSeries", slug: $slug }, startDateWithTime: ">= now", orderBy: "startDateWithTime ASC") {
-  #     uri
-  #     sectionHandle
-  #     eventTitle
-  #     startDateWithTime
-  #     ftvaImage {
-  #       ...Image
-  #     }
-  #     ftvaEventFilters {
-  #       title
-  #     }
-  # }
-  # pastEvents: entries(section: "ftvaEvent",  relatedToEntries: { section: "ftvaEventSeries", slug: $slug }, startDateWithTime: "< now", orderBy: "startDateWithTime ASC") {
-  #   uri
-  #   sectionHandle
-  #   eventTitle
-  #   startDateWithTime
-  #   ftvaImage {
-  #     ...Image
-  #   }
-  #   ftvaEventFilters {
-  #     title
-  #   }
-  # }
   otherSeriesOngoing: entries(section: "ftvaEventSeries", limit: 3, ongoing: true) {
     uri
     sectionHandle
     title
-    startDate
-    endDate
+    startDate @formatDateTime(format: "Y-m-d\\TH:i", timezone: "America/Los_Angeles")
+    endDate @formatDateTime(format: "Y-m-d\\TH:i", timezone: "America/Los_Angeles")
     ongoing
     ftvaImage {
       ...Image
@@ -116,8 +103,8 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
     uri
     sectionHandle
     title
-    startDate
-    endDate
+    startDate @formatDateTime(format: "Y-m-d\\TH:i", timezone: "America/Los_Angeles")
+    endDate @formatDateTime(format: "Y-m-d\\TH:i", timezone: "America/Los_Angeles")
     ongoing
     ftvaImage {
       ...Image

--- a/gql/queries/FTVAEventSeriesList.gql
+++ b/gql/queries/FTVAEventSeriesList.gql
@@ -12,8 +12,8 @@ query FTVAEventSeriesList {
       # image: ftvaImage {
       #  ...Image
       # }
-      startDate @formatDateTime(format: "Y-m-d", timezone: "America/Los_Angeles")
-      endDate @formatDateTime(format: "Y-m-d", timezone: "America/Los_Angeles")
+      startDate @formatDateTime(format: "Y-m-d\\TH:i:s", timezone: "America/Los_Angeles")
+      endDate @formatDateTime(format: "Y-m-d\\TH:i:s", timezone: "America/Los_Angeles")
     }
   }
 }


### PR DESCRIPTION
Connected to [APPS-2970](https://jira.library.ucla.edu/browse/APPS-2970)

**Page/Pages Created/updated:** {filename}.vue from #{issue number}

**Notes:**

In progress

Axa met with me Friday (10/4) to discuss and had already done some testing. She indicated (and the library-website-nuxt site agrees) that we need to use @formatDateTime functions to format the dateTimes to the correct timezone. Otherwise, netlify's server times will dictate time zone on production, leading to mismatches and bugs. 

**Time Report:**

This took me 2ish hours so far to build this.

**Checklist:**

-   [X] I added github label for semantic versioning
- ~~[ ] I double checked it looks like the designs~~
- ~~[ ] I completed any required mobile breakpoint styling~~
- ~~[ ] I completed any required hover state styling~~
- ~~[ ] I included a working spec file~~
-   [ ] I added notes above about how long it took to build this component
-   [ ] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-2970]: https://uclalibrary.atlassian.net/browse/APPS-2970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ