### PR TITLE
fix: APPS-2998 Update inline carousels with new prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
 		"nuxt-graphql-request": "^7.0.5",
 		"sass": "^1.66.1",
 		"ucla-library-design-tokens": "^5.22.0",
-		"ucla-library-website-components": "3.26.0"
+		"ucla-library-website-components": "3.28.0"
 	}
 }

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -140,6 +140,7 @@ const parsedFTVAEventScreeningDetails = computed(() => {
         <FlexibleMediaGalleryNewLightbox
           data-test="image-carousel"
           :items="parsedCarouselData"
+          inline="true"
         >
           <template #default="slotProps">
             <BlockTag

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -196,7 +196,10 @@ onMounted(() => {
         v-else
         class="lightbox-container"
       >
-        <FlexibleMediaGalleryNewLightbox :items="parsedCarouselData">
+        <FlexibleMediaGalleryNewLightbox
+          :items="parsedCarouselData"
+          inline="true"
+        >
           <template #default="slotProps">
             <BlockTag :label="parsedCarouselData[slotProps.selectionIndex]?.creditText" />
           </template>
@@ -312,10 +315,7 @@ onMounted(() => {
   </main>
 </template>
 
-<style
-  lang="scss"
-  scoped
->
+<style lang="scss" scoped>
 // GENERAL PAGE STYLES / DESKTOP
 .page-event-series-detail {
   position: relative;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ devDependencies:
     specifier: ^5.22.0
     version: 5.22.0
   ucla-library-website-components:
-    specifier: 3.26.0
-    version: 3.26.0(typescript@5.4.5)(vue@3.4.31)
+    specifier: 3.28.0
+    version: 3.28.0(typescript@5.4.5)(vue@3.4.31)
 
 packages:
 
@@ -1149,6 +1149,9 @@ packages:
     resolution: {integrity: sha512-7nhBTRkTG0mD+7r7JvNalJz++YwszZk0oP1HIY6fCgz6wNKxT6LuiXCqdPrZmNPe/WbPIKuqxGZN5s+i6NZqow==}
     peerDependencies:
       vue: '>= 3.2.0 < 4.0.0'
+    peerDependenciesMeta:
+      vue-router:
+        optional: true
     dependencies:
       '@gtm-support/core': 2.3.1
       vue: 3.4.31(typescript@5.4.5)
@@ -9988,8 +9991,8 @@ packages:
     resolution: {integrity: sha512-HudkrR/TMd5FTV1VGqOrYLg4bsDgb8kgml6rtDF3NgS9vf0hfQyVipxjbEHlfvuPHtQ7RZcn6ftdJHi92JqfSw==}
     dev: true
 
-  /ucla-library-website-components@3.26.0(typescript@5.4.5)(vue@3.4.31):
-    resolution: {integrity: sha512-g56cx6ntsl4dROSjrEGCa+mA++mXRIX3dUrVsCy0AL9EauXk9bUZGWnK0fKg3qXo7+UFICZztqcN5wDsapEB3w==}
+  /ucla-library-website-components@3.28.0(typescript@5.4.5)(vue@3.4.31):
+    resolution: {integrity: sha512-DwxOxUzFfZWn57zw2oGCUZK9EzQt+7OoRv87j/cMFM3C6tlswb8sQbKJp0XUnZFMq38XweHXQWpbWLOFAPZE4Q==}
     peerDependencies:
       vue: ^3.4.29
     dependencies:


### PR DESCRIPTION
Connected to [APPS-2998](https://jira.library.ucla.edu/browse/APPS-2998)

**Pages Updated:**
- pages/events/[slug].vue
- pages/series/[slug].vue

**Notes:**
- Updated library component package from `3.27.0` to `3.28.0` to include FTVA variants of MediaGallery components
- Add `inline=true` to inline use cases of MediaGalleryNewLightbox

<br>

**Deploy Previews:**
- Event page (Inline): https://deploy-preview-49--test-ftva.netlify.app/events/la-r%C3%A9gion-centrale-03-08-24/
- Series page (Inline): https://deploy-preview-49--test-ftva.netlify.app/series/step-up-series
- Blog page (Lightbox): https://deploy-preview-49--test-ftva.netlify.app/blog/test-tom-reeds-for-members-only-black-perspectives-on-local-l-a-tv

<br>

**Local Previews:**
*Event page - Inline Carousel:*

![event-page](https://github.com/user-attachments/assets/6062f145-85ea-4b9e-ad33-3287756f37dd)

<br>

*Series page - Inline Carousel:*

![series-page](https://github.com/user-attachments/assets/a9129d0e-4034-42e0-b84e-b04f2ad62b9e)

<br>

*Blog page - Lightbox:*

![blog-page](https://github.com/user-attachments/assets/d68598c2-a3b2-495e-b979-ec05983b11de)

<br>

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I double checked it looks like the designs
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~
-   [x] I requested a PR review from the Dev team


[APPS-2998]: https://uclalibrary.atlassian.net/browse/APPS-2998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ