### PR TITLE
feat: APPS-2997 finish collection detail page

### DIFF
--- a/cypress/e2e/collectionDetailPage.cy.js
+++ b/cypress/e2e/collectionDetailPage.cy.js
@@ -2,10 +2,10 @@ describe('Collection Detail Page', () => {
   it('Visits a Collection Detail Page', () => {
     cy.visit('/collections/test-get-used-to-it')
     cy.getByData('breadcrumb').should('be.visible')
-    // sharebutton should be visible
-    cy.getByData('share-button').should('be.visible')
+    // sharebutton should exist
+    cy.getByData('share-button').should('exist')
     // cta should be in sidebar w specific data
-    cy.getByData('sidebar-cta').should('be.visible')
+    cy.getByData('sidebar-cta').should('exist')
     cy.percySnapshot('collectiondetailpage', { widths: [768, 992, 1200] })
   })
 })

--- a/cypress/e2e/collectionDetailPage.cy.js
+++ b/cypress/e2e/collectionDetailPage.cy.js
@@ -1,9 +1,11 @@
 describe('Collection Detail Page', () => {
   it('Visits a Collection Detail Page', () => {
-    cy.visit('/collections/test-collection-two')
+    cy.visit('/collections/test-get-used-to-it')
     cy.getByData('breadcrumb').should('be.visible')
     // sharebutton should be visible
+    cy.getByData('share-button').should('be.visible')
     // cta should be in sidebar w specific data
+    cy.getByData('sidebar-cta').should('be.visible')
     cy.percySnapshot('collectiondetailpage', { widths: [768, 992, 1200] })
   })
 })

--- a/cypress/e2e/collectionDetailPage.cy.js
+++ b/cypress/e2e/collectionDetailPage.cy.js
@@ -1,0 +1,9 @@
+describe('Collection Detail Page', () => {
+  it('Visits a Collection Detail Page', () => {
+    cy.visit('/collections/test-collection-two')
+    cy.getByData('breadcrumb').should('be.visible')
+    // sharebutton should be visible
+    // cta should be in sidebar w specific data
+    cy.percySnapshot('collectiondetailpage', { widths: [768, 992, 1200] })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
 		"nuxt-graphql-request": "^7.0.5",
 		"sass": "^1.66.1",
 		"ucla-library-design-tokens": "^5.27.0",
-		"ucla-library-website-components": "3.29.0"
+		"ucla-library-website-components": "3.29.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"lodash": "^4.17.21",
 		"nuxt-graphql-request": "^7.0.5",
 		"sass": "^1.66.1",
-		"ucla-library-design-tokens": "^5.22.0",
-		"ucla-library-website-components": "3.28.0"
+		"ucla-library-design-tokens": "^5.27.0",
+		"ucla-library-website-components": "3.29.0"
 	}
 }

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -128,6 +128,7 @@ const parsedRecentPosts = computed(() => {
         <FlexibleMediaGalleryNewLightbox
           data-test="image-carousel"
           :items="parsedCarouselData"
+          :inline="true"
         >
           <template #default="slotProps">
             <BlockTag

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -124,6 +124,7 @@ useHead({
   >
     <div class="one-column">
       <NavBreadcrumb
+        data-test="breadcrumb"
         class="breadcrumb"
         :title="page?.title"
         to="/collections"

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -73,7 +73,7 @@ const parsedInfoBlockIconLookup = {
 }
 const parsedInfoBlock = computed(() => {
   // fail gracefully if data does not exist (server-side)
-  if (!page.value.infoBlock) {
+  if (!page.value.infoBlock || page.value.infoBlock.length === 0) {
     return null
   }
   return page.value.infoBlock.map((item, index) => {
@@ -83,6 +83,13 @@ const parsedInfoBlock = computed(() => {
       icon: parsedIcon
     }
   })
+})
+const parsedRelatedCollectionsHeader = computed(() => {
+  // fail gracefully if data does not exist (server-side)
+  if (!page.value.sectionTitle) {
+    return 'Related Collections'
+  }
+  return page.value.sectionTitle ? page.value.sectionTitle : 'Related Collections'
 })
 const parsedRelatedCollections = computed(() => {
   // fail gracefully if data does not exist (server-side)
@@ -212,7 +219,7 @@ useHead({
     <SectionWrapper
       v-if="parsedRelatedCollections && parsedRelatedCollections.length > 0"
       theme="paleblue"
-      :section-title="page.sectionTitle"
+      :section-title="parsedRelatedCollectionsHeader"
       class="series-section-wrapper"
     >
       <template #top-right>

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -102,6 +102,7 @@ const parsedRelatedCollections = computed(() => {
       ...item,
       to: `/${item.uri}`, // remove 'collection/' from uri
       category: 'collection',
+      bylineOne: item.richText,
       image: item.ftvaImage && item.ftvaImage.length > 0 ? item.ftvaImage[0] : null,
     }
   })
@@ -182,7 +183,6 @@ useHead({
       </template>
 
       <!-- Sidebar -->
-      <!-- may need to move to diff slot? -->
       <template #sidebarTop>
         <BlockCallToAction
           :use-global-data="true"
@@ -194,7 +194,6 @@ useHead({
           v-if="page?.richText"
           :rich-text-content="page?.richText"
         />
-        <!-- todo poster image support check craft CMS test data -->
         <DividerWayFinder v-if="page.videoEmbed" />
         <VideoEmbed
           v-if="page.videoEmbed"
@@ -215,7 +214,6 @@ useHead({
         </div>
       </template>
     </TwoColLayoutWStickySideBar>
-    <!-- <div> {{ page }}</div> -->
     <SectionWrapper
       v-if="parsedRelatedCollections && parsedRelatedCollections.length > 0"
       theme="paleblue"
@@ -231,7 +229,7 @@ useHead({
         </nuxt-link>
       </template>
       <SectionTeaserCard
-        class="other-series-section"
+        class="related-collections-card"
         :items="parsedRelatedCollections"
       />
     </SectionWrapper>
@@ -272,6 +270,12 @@ useHead({
 
     .section-wrapper.theme-paleblue {
       background-color: var(--pale-blue);
+    }
+  }
+
+  .related-collections-card {
+    :deep(.byline-group) {
+      @include truncate(2);
     }
   }
 }

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -235,7 +235,6 @@ useHead({
 .page-collection-detail {
   position: relative;
 
-  // TODO move this element to global mixin or something, its on every detail page
   &:before {
     content: '';
     position: absolute;
@@ -247,7 +246,6 @@ useHead({
     z-index: -1;
   }
 
-  // TODO global?
   .one-column {
     width: 100%;
     max-width: var(--max-width);
@@ -258,7 +256,6 @@ useHead({
     }
   }
 
-  // TODO global?
   .full-width {
     width: 100%;
     background-color: var(--pale-blue);

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -59,13 +59,6 @@ const parsedCarouselData = computed(() => {
     }
   })
 })
-const parsedCollectionType = computed(() => {
-  if (page.value.ftvaCollectionType) {
-    // split camelCase items in list and join with space, then join list with comma
-    return page.value.ftvaCollectionType.map(str => str.split(/(?=[A-Z])/).join(' ')).join(', ')
-  }
-  return null
-})
 // Map icon names to svg names for infoBlock
 const parsedInfoBlockIconLookup = {
   'icon-download': 'svg-call-to-action-ftva-pdf',
@@ -100,7 +93,7 @@ const parsedRelatedCollections = computed(() => {
   const relatedCollections = page.value.ftvaRelatedCollections.map((item, index) => {
     return {
       ...item,
-      to: `/${item.uri}`, // remove 'collection/' from uri
+      to: `/${item.uri}`,
       category: 'collection',
       bylineOne: item.richText,
       image: item.ftvaImage && item.ftvaImage.length > 0 ? item.ftvaImage[0] : null,
@@ -169,7 +162,7 @@ useHead({
     <TwoColLayoutWStickySideBar>
       <template #primaryTop>
         <CardMeta
-          :category="parsedCollectionType"
+          category="Collection"
           :title="page?.title"
         >
           <template #sharebutton>

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -168,6 +168,7 @@ useHead({
         >
           <template #sharebutton>
             <ButtonDropdown
+              data-test="share-button"
               button-title="Share"
               :has-icon="true"
               :dropdown-list="socialList.dropdownList"
@@ -179,6 +180,7 @@ useHead({
       <!-- Sidebar -->
       <template #sidebarTop>
         <BlockCallToAction
+          data-test="sidebar-cta"
           :use-global-data="true"
           :is-centered="false"
         />

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -266,6 +266,14 @@ useHead({
     }
   }
 
+  .cta-block {
+    :deep(.block-call-to-action) {
+      &:not(:last-child) {
+        margin-bottom: 16px;
+      }
+    }
+  }
+
   .related-collections-card {
     :deep(.byline-group) {
       @include truncate(2);

--- a/pages/collections/index.vue
+++ b/pages/collections/index.vue
@@ -60,7 +60,7 @@ useHead({
         <divider-general />
       </div>
 
-      <code><strong>PAGE</strong> {{ page }}</code>
+      <!-- <code><strong>PAGE</strong> {{ page }}</code> -->
     </section-wrapper>
   </div>
 </template>

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -139,32 +139,6 @@ const parsedOtherSeries = computed(() => {
   })
   return otherSeries
 })
-
-// MOBILE LOGIC
-const globalStore = useGlobalStore()
-const isMobile = ref(false)
-watch(globalStore, (newVal, oldVal) => {
-  isMobile.value = globalStore.winWidth <= 750
-})
-
-// LAYOUT & STYLES
-// TO DO THIS SECTION MAY BE WORTH ADDING TO 2 COL SIDE BAR LAYOUT
-// Track height of sidebar and ensure main content as at least as tall
-const sidebar = ref(null)
-const primaryCol = ref(null)
-
-watch([isMobile, sidebar], ([newValIsMobile, newValSidebar], [oldValGlobalStore, oldValSidebar]) => {
-  if (newValIsMobile === true) {
-    primaryCol.value.style.minHeight = 'auto' // on mobile, reset height
-  } else {
-    primaryCol.value.style.minHeight = `${newValSidebar.clientHeight + 125}px`
-  }
-}, { deep: true })
-
-// globalstore state is lost when error page is generated , this is hack to repopulate state on client side
-onMounted(() => {
-  isMobile.value = globalStore.winWidth <= 750 // 750px is the breakpoint for mobile
-})
 </script>
 
 <template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ devDependencies:
     specifier: ^5.27.0
     version: 5.27.0
   ucla-library-website-components:
-    specifier: 3.29.0
-    version: 3.29.0(typescript@5.4.5)(vue@3.4.31)
+    specifier: 3.29.1
+    version: 3.29.1(typescript@5.4.5)(vue@3.4.31)
 
 packages:
 
@@ -9988,8 +9988,8 @@ packages:
     resolution: {integrity: sha512-jo1AgrDLzUOcdMHTVZ3HvNmMJrZ0gJMrecGiG0brpmyIm7SeNv6rimf0PN3GF87COhj2oYrZ7PocovU4f7GJEw==}
     dev: true
 
-  /ucla-library-website-components@3.29.0(typescript@5.4.5)(vue@3.4.31):
-    resolution: {integrity: sha512-acxMa4uDTKH/QIMCiMmzIdPE3b8EflI6d4vd9c0womLkhzlp4Mlm80uWcgv2vIHoehRc1BhyCsXNmfiLRnkmSQ==}
+  /ucla-library-website-components@3.29.1(typescript@5.4.5)(vue@3.4.31):
+    resolution: {integrity: sha512-YwI+24tR6JqAMTvtTuj76UQdL6ysWSbtMMzxUu2B9UfVtSc/j6X77uJEhSMjfQK5kL19LVeBX36xb5Cb07s+cA==}
     peerDependencies:
       vue: ^3.4.29
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,11 +65,11 @@ devDependencies:
     specifier: ^1.66.1
     version: 1.77.4
   ucla-library-design-tokens:
-    specifier: ^5.22.0
-    version: 5.22.0
+    specifier: ^5.27.0
+    version: 5.27.0
   ucla-library-website-components:
-    specifier: 3.28.0
-    version: 3.28.0(typescript@5.4.5)(vue@3.4.31)
+    specifier: 3.29.0
+    version: 3.29.0(typescript@5.4.5)(vue@3.4.31)
 
 packages:
 
@@ -1149,9 +1149,6 @@ packages:
     resolution: {integrity: sha512-7nhBTRkTG0mD+7r7JvNalJz++YwszZk0oP1HIY6fCgz6wNKxT6LuiXCqdPrZmNPe/WbPIKuqxGZN5s+i6NZqow==}
     peerDependencies:
       vue: '>= 3.2.0 < 4.0.0'
-    peerDependenciesMeta:
-      vue-router:
-        optional: true
     dependencies:
       '@gtm-support/core': 2.3.1
       vue: 3.4.31(typescript@5.4.5)
@@ -9987,12 +9984,12 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /ucla-library-design-tokens@5.22.0:
-    resolution: {integrity: sha512-HudkrR/TMd5FTV1VGqOrYLg4bsDgb8kgml6rtDF3NgS9vf0hfQyVipxjbEHlfvuPHtQ7RZcn6ftdJHi92JqfSw==}
+  /ucla-library-design-tokens@5.27.0:
+    resolution: {integrity: sha512-jo1AgrDLzUOcdMHTVZ3HvNmMJrZ0gJMrecGiG0brpmyIm7SeNv6rimf0PN3GF87COhj2oYrZ7PocovU4f7GJEw==}
     dev: true
 
-  /ucla-library-website-components@3.28.0(typescript@5.4.5)(vue@3.4.31):
-    resolution: {integrity: sha512-DwxOxUzFfZWn57zw2oGCUZK9EzQt+7OoRv87j/cMFM3C6tlswb8sQbKJp0XUnZFMq38XweHXQWpbWLOFAPZE4Q==}
+  /ucla-library-website-components@3.29.0(typescript@5.4.5)(vue@3.4.31):
+    resolution: {integrity: sha512-acxMa4uDTKH/QIMCiMmzIdPE3b8EflI6d4vd9c0womLkhzlp4Mlm80uWcgv2vIHoehRc1BhyCsXNmfiLRnkmSQ==}
     peerDependencies:
       vue: ^3.4.29
     dependencies:


### PR DESCRIPTION
Connected to [APPS-2997](https://jira.library.ucla.edu/browse/APPS-2997)

**Page/Pages Created/updated:** /collections/[slug].vue, /collections/index.vue from #{APPS-2997}

**Notes:**

- updated tokens and component packages to latest
- updated page to use carousel inline
- created computed functions to parse data for related collections section, also to set defaults for sectionHeader, viewAllLink text and uri
- created computed functions for infoBlock data and rendered it with new CallToAction blocks 
- added a cypress test
- removed old un-needed code for sidebar from /series/slug page
- made sure carousel is inline in blog page

Questions for team:

Growing Tech Debt
There are some repeated bits of code starting to grow such as logic for carousel / image at top of page and styles for that large blue box at the top of the page. Im wondering if I should make a ticket to work on next week before these are duplicated further. Or I can do it as part of this PR? 

onMounted? Should I be using it?
I remember Parinita fixed some hydration errors using onMounted in other pages, Im wondering if anything Im doing here (like setting up watchers) should be moved to onMounted as a matter of good practice? I matched the existing patterns we’ve used in the other pages so far, but I wasn’t sure

**Time Report:**

This took me 6ish hours to build this.

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   [X] I completed any required mobile breakpoint styling
-   [X] I completed any required hover state styling
-   [X] I included a working spec file
-   [X] I added notes above about how long it took to build this component
-   [X] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-2997]: https://uclalibrary.atlassian.net/browse/APPS-2997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ