### PR TITLE
fix: APPS-2968   EventSeriesDetail - Sort past events by DESC order

### DIFF
--- a/gql/queries/FTVAEventSeriesDetail.gql
+++ b/gql/queries/FTVAEventSeriesDetail.gql
@@ -15,7 +15,7 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
     ftvaEventIntroduction
     eventDescription
     acknowledgement: richText
-    startDate 
+    startDate
       @formatDateTime(
         format: "Y-m-d\\TH:i"
         timezone: "America/Los_Angeles"
@@ -58,7 +58,7 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
       to: uri
       sectionHandle
       title: eventTitle
-      startDateWithTime 
+      startDateWithTime
         @formatDateTime(
           format: "Y-m-d\\TH:i"
           timezone: "America/Los_Angeles"
@@ -72,7 +72,7 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
         title
       }
   }
-  pastEvents: entries(section: "ftvaEvent", relatedToEntries: { section: "ftvaEventSeries", slug: $slug }, startDateWithTime: "< now", orderBy: "startDateWithTime ASC") {
+  pastEvents: entries(section: "ftvaEvent", relatedToEntries: { section: "ftvaEventSeries", slug: $slug }, startDateWithTime: "< now", orderBy: "startDateWithTime DESC") {
     to: uri
     title: eventTitle
     startDateWithTime @formatDateTime(


### PR DESCRIPTION
Connected to [APPS-2968](https://jira.library.ucla.edu/browse/APPS-2968)

BEFORE (sort by ASC order)
![Screenshot 2024-10-17 at 11 27 36 AM](https://github.com/user-attachments/assets/955f2a93-bcb5-41a4-b21e-f4a16aea3489)

AFTER (sort by DESC order)
![Screenshot 2024-10-17 at 11 28 25 AM](https://github.com/user-attachments/assets/356c0337-6e47-44a3-a432-ad807a475be4)


[APPS-2968]: https://uclalibrary.atlassian.net/browse/APPS-2968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ