### PR TITLE
fix: APPS-2965 Update series page breadcrumb parent title

### DIFF
--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -162,7 +162,7 @@ useHead({
         class="breadcrumb"
         :title="page?.title"
         to="/series"
-        parent-title="Screening Series"
+        parent-title="Series"
       />
 
       <ResponsiveImage


### PR DESCRIPTION
Connected to [APPS-2965](https://jira.library.ucla.edu/browse/APPS-2965)

**Page Updated:** pages/series/[slug].vue

**Notes:**
- Updated parent title from `Screening Series` to `Series`

![series-page-parent-breadcrumb-before](https://github.com/user-attachments/assets/fe9c2961-31df-4dc8-84c2-e09b3f366a5e)

![series-page-parent-breadcrumb-after](https://github.com/user-attachments/assets/4962d8e0-871f-4502-9e50-c461504495eb)

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I requested a PR review from the Dev team
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~



[APPS-2965]: https://uclalibrary.atlassian.net/browse/APPS-2965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ