### PR TITLE
feat: APPS-3007 Add BlockInfo external icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
 		"nuxt-graphql-request": "^7.0.5",
 		"sass": "^1.66.1",
 		"ucla-library-design-tokens": "^5.27.0",
-		"ucla-library-website-components": "3.31.4"
+		"ucla-library-website-components": "3.31.6"
 	}
 }

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -1,4 +1,4 @@
-<script lang="ts" setup>
+<script setup>
 // COMPONENT RE-IMPORTS
 // TODO: remove when we have implemented component library as a module
 // https://nuxt.com/docs/guide/directory-structure/components#library-authors
@@ -63,7 +63,8 @@ const parsedCarouselData = computed(() => {
 // Map icon names to svg names for infoBlock
 const parsedInfoBlockIconLookup = {
   'icon-download': 'svg-call-to-action-ftva-pdf',
-  'icon-external-link': 'svg-call-to-action-ftva-info'
+  'icon-info': 'svg-call-to-action-ftva-info',
+  'icon-external-link': 'svg-call-to-action-ftva-external-link-dark'
 }
 const parsedInfoBlock = computed(() => {
   // fail gracefully if data does not exist (server-side)

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -72,7 +72,7 @@ const parsedInfoBlock = computed(() => {
     return null
   }
   return page.value.infoBlock.map((item, index) => {
-    const parsedIcon = parsedInfoBlockIconLookup[item?.icon] ? parsedInfoBlockIconLookup[item.icon] : parsedInfoBlockIconLookup['icon-external-link']
+    const parsedIcon = parsedInfoBlockIconLookup[item?.icon] ? parsedInfoBlockIconLookup[item.icon] : parsedInfoBlockIconLookup['icon-info']
     return {
       text: item.text,
       icon: parsedIcon

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -275,6 +275,12 @@ useHead({
     }
   }
 
+  :deep(.primary-column) {
+    .svg__icon-ftva-external-link-dark {
+      top: 5px;
+    }
+  }
+
   .cta-block {
     :deep(.block-call-to-action) {
       &:not(:last-child) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ devDependencies:
     specifier: ^5.27.0
     version: 5.27.0
   ucla-library-website-components:
-    specifier: 3.31.4
-    version: 3.31.4(typescript@5.4.5)(vue@3.4.31)
+    specifier: 3.31.6
+    version: 3.31.6(typescript@5.4.5)(vue@3.4.31)
 
 packages:
 
@@ -10050,8 +10050,8 @@ packages:
     resolution: {integrity: sha512-jo1AgrDLzUOcdMHTVZ3HvNmMJrZ0gJMrecGiG0brpmyIm7SeNv6rimf0PN3GF87COhj2oYrZ7PocovU4f7GJEw==}
     dev: true
 
-  /ucla-library-website-components@3.31.4(typescript@5.4.5)(vue@3.4.31):
-    resolution: {integrity: sha512-smdxr77ipH1/BRI59Zna3zi15Hd/88TfIERTgwg+jbJdzsShVDDsWxHZnTtDt3vLcNrL79T+x2EYEx2JSIGpCg==}
+  /ucla-library-website-components@3.31.6(typescript@5.4.5)(vue@3.4.31):
+    resolution: {integrity: sha512-lIdcuuUqBOyiAgSlxDh/8AJE8PCIgogC1hR1gEHAT+y98hfka40tYDuFjxlMfZsRIXr3fAAqeav3WUtIq0CNRg==}
     peerDependencies:
       vue: ^3.5.12
     dependencies:


### PR DESCRIPTION
Connected to [APPS-3007](https://jira.library.ucla.edu/browse/APPS-3007)

**Page Updated:** /pages/collections/[slug].vue

**Notes:**
- Update icon lookup with ftva-external-link name
- Update component package from `3.31.6`

https://deploy-preview-59--test-ftva.netlify.app/collections/test-get-used-to-it/

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I double checked it looks like the designs
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~
-   [x] I have requested a PR review from the Dev team


[APPS-3007]: https://uclalibrary.atlassian.net/browse/APPS-3007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ