### PR TITLE
feat: APPS-3010 Consolidate slug page styles

### DIFF
--- a/assets/styles/slug-pages.scss
+++ b/assets/styles/slug-pages.scss
@@ -2,7 +2,8 @@
 
 .page-article-detail,
 .page-collection-detail,
-.page-event-detail {
+.page-event-detail,
+.page-event-series-detail {
   &:before {
     content: '';
     position: absolute;

--- a/assets/styles/slug-pages.scss
+++ b/assets/styles/slug-pages.scss
@@ -1,6 +1,7 @@
 /* Shared styles for [slug].vue */
 
-.page-article-detail {
+.page-article-detail,
+.page-collection-detail {
   &:before {
     content: '';
     position: absolute;

--- a/assets/styles/slug-pages.scss
+++ b/assets/styles/slug-pages.scss
@@ -1,7 +1,8 @@
 /* Shared styles for [slug].vue */
 
 .page-article-detail,
-.page-collection-detail {
+.page-collection-detail,
+.page-event-detail {
   &:before {
     content: '';
     position: absolute;

--- a/assets/styles/slug-pages.scss
+++ b/assets/styles/slug-pages.scss
@@ -1,9 +1,6 @@
 /* Shared styles for [slug].vue */
 
-.page-article-detail,
-.page-collection-detail,
-.page-event-detail,
-.page-event-series-detail {
+.page-detail {
   &:before {
     content: '';
     position: absolute;

--- a/assets/styles/slug-pages.scss
+++ b/assets/styles/slug-pages.scss
@@ -1,0 +1,31 @@
+/* Shared styles for [slug].vue */
+
+.page-article-detail {
+  &:before {
+    content: '';
+    position: absolute;
+    background-color: var(--pale-blue);
+    aspect-ratio: 1440 / 520;
+    max-height: 518px; //prevent overflow on large screens
+    min-height: 225px; //prevent too much shrinking on small screens
+    width: 100%;
+    z-index: -1;
+  }
+
+  .one-column {
+    width: 100%;
+    max-width: var(--max-width);
+    margin: 0 auto;
+
+    :deep(.nav-breadcrumb) {
+      padding: 0px;
+    }
+  }
+
+  @media (max-width: 1200px) {
+    .one-column {
+      padding-left: var(--unit-gutter);
+      padding-right: var(--unit-gutter);
+    }
+  }
+}

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -210,10 +210,7 @@ useHead({
   </main>
 </template>
 
-<style
-  lang="scss"
-  scoped
->
+<style lang="scss" scoped>
 // PAGE STYLES
 .page-article-detail {
   position: relative;
@@ -253,7 +250,7 @@ useHead({
     padding-bottom: 4px;
   }
 
-  // remove max-width from rich-text inside flexible-blocks for ftva
+  /* remove max-width from rich-text inside flexible-blocks for ftva */
   :deep(.flexible-block) {
     .rich-text {
       max-width: none;

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -110,7 +110,7 @@ useHead({
 <template>
   <main
     id="main"
-    class="page page-article-detail"
+    class="page page-detail page-article-detail"
   >
     <div class="one-column">
       <NavBreadcrumb

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -218,27 +218,6 @@ useHead({
 .page-article-detail {
   position: relative;
 
-  &:before {
-    content: '';
-    position: absolute;
-    background-color: var(--pale-blue);
-    aspect-ratio: 1440 / 520;
-    max-height: 518px; //prevent overflow on large screens
-    min-height: 225px; //prevent too much shrinking on small screens
-    width: 100%;
-    z-index: -1;
-  }
-
-  .one-column {
-    width: 100%;
-    max-width: var(--max-width);
-    margin: 0 auto;
-
-    :deep(.nav-breadcrumb) {
-      padding: 0px;
-    }
-  }
-
   // makes all EventSeries same height
   :deep(.card) {
     min-height: 350px;
@@ -283,8 +262,6 @@ useHead({
   }
 
   @media (max-width: 1200px) {
-
-    .one-column,
     .two-column {
       padding-left: var(--unit-gutter);
       padding-right: var(--unit-gutter);
@@ -315,4 +292,6 @@ useHead({
     }
   }
 }
+
+@import 'assets/styles/slug-pages.scss';
 </style>

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -129,7 +129,7 @@ useHead({
 <template>
   <main
     id="main"
-    class="page page-collection-detail"
+    class="page page-detail page-collection-detail"
   >
     <div class="one-column">
       <NavBreadcrumb

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -244,27 +244,6 @@ useHead({
 .page-collection-detail {
   position: relative;
 
-  &:before {
-    content: '';
-    position: absolute;
-    background-color: var(--pale-blue);
-    aspect-ratio: 1440 / 520;
-    max-height: 518px; //prevent overflow on large screens
-    min-height: 225px; //prevent too much shrinking on small screens
-    width: 100%;
-    z-index: -1;
-  }
-
-  .one-column {
-    width: 100%;
-    max-width: var(--max-width);
-    margin: 0 auto;
-
-    :deep(.nav-breadcrumb) {
-      padding: 0px;
-    }
-  }
-
   .full-width {
     width: 100%;
     background-color: var(--pale-blue);
@@ -295,4 +274,6 @@ useHead({
     }
   }
 }
+
+@import 'assets/styles/slug-pages.scss';
 </style>

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -123,7 +123,7 @@ useHead({
 <template>
   <main
     id="main"
-    class="page page-event-detail"
+    class="page page-detail page-event-detail"
   >
     <div class="one-column">
       <NavBreadcrumb

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -252,34 +252,10 @@ useHead({
   </main>
 </template>
 
-<style
-  lang="scss"
-  scoped
->
+<style lang="scss" scoped>
 // PAGE STYLES
 .page-event-detail {
   position: relative;
-
-  &:before {
-    content: '';
-    position: absolute;
-    background-color: var(--pale-blue);
-    aspect-ratio: 1440 / 520;
-    max-height: 518px; //prevent overflow on large screens
-    min-height: 225px; //prevent too much shrinking on small screens
-    width: 100%;
-    z-index: -1;
-  }
-
-  .one-column {
-    width: 100%;
-    max-width: var(--max-width);
-    margin: 0 auto;
-
-    :deep(.nav-breadcrumb) {
-      padding: 0px;
-    }
-  }
 
   .two-column {
 
@@ -304,13 +280,6 @@ useHead({
   }
 
   @media (max-width: 1200px) {
-
-    // .two-column
-    .one-column {
-      padding-left: var(--unit-gutter);
-      padding-right: var(--unit-gutter);
-    }
-
     :deep(.primary-column) {
       width: 65%;
     }
@@ -326,4 +295,6 @@ useHead({
     }
   }
 }
+
+@import 'assets/styles/slug-pages.scss';
 </style>

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -155,7 +155,7 @@ useHead({
 <template>
   <main
     id="main"
-    class="page page-event-series-detail"
+    class="page page-detail page-event-series-detail"
   >
     <div class="one-column">
       <NavBreadcrumb

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -305,27 +305,6 @@ useHead({
 .page-event-series-detail {
   position: relative;
 
-  &:before {
-    content: '';
-    position: absolute;
-    background-color: var(--pale-blue);
-    aspect-ratio: 1440 / 520;
-    max-height: 518px; //prevent overflow on large screens
-    min-height: 225px; //prevent too much shrinking on small screens
-    width: 100%;
-    z-index: -1;
-  }
-
-  .one-column {
-    width: 100%;
-    max-width: var(--max-width);
-    margin: 0 auto;
-
-    :deep(.nav-breadcrumb) {
-      padding: 0px;
-    }
-  }
-
   .full-width {
     width: 100%;
     background-color: var(--pale-blue);
@@ -368,14 +347,11 @@ useHead({
   // MEDIUM DEVICE STYLES
   @media (max-width: 1200px) {
 
-    .one-column {
-      padding-left: var(--unit-gutter);
-      padding-right: var(--unit-gutter);
-    }
-
     .two-column {
       padding-right: 0;
     }
   }
 }
+
+@import 'assets/styles/slug-pages.scss';
 </style>


### PR DESCRIPTION
Connected to [APPS-3010](https://jira.library.ucla.edu/browse/APPS-3010)

**Pages Updated:**
- /pages/blog/[slug].vue
- /pages/collection/[slug].vue
- /pages/events/[slug].vue
- /pages/series/[slug].vue

**Notes:**
- Consolidate similar slug page styles into a single .scss file for easy maintenance

**Previews:**
- Blog: https://deploy-preview-65--test-ftva.netlify.app/blog/test-tom-reeds-for-members-only-black-perspectives-on-local-l-a-tv
- Collection: https://deploy-preview-65--test-ftva.netlify.app/collections/test-get-used-to-it/
- Events: https://deploy-preview-65--test-ftva.netlify.app/events/the-pink-cloud-shorts-03-02-24/
- Series: https://deploy-preview-65--test-ftva.netlify.app/series/step-up-series

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I have requested a PR review from the Dev team
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~


[APPS-3010]: https://uclalibrary.atlassian.net/browse/APPS-3010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ