### PR TITLE
fix: APPS-3054 Update Queries, Composable, Logic for Event filters

### DIFF
--- a/composables/useIndexAggregator.js
+++ b/composables/useIndexAggregator.js
@@ -19,7 +19,13 @@ export async function useIndexAggregator() {
           aggs: {
             'Event Type': {
               terms: {
-                field: 'tagLabels.title.keyword',
+                field: 'ftvaEventTypeFilters.title.keyword',
+                size: 100
+              }
+            },
+            'Film Format': {
+              terms: {
+                field: 'ftvaScreeningFormatFilters.title.keyword',
                 size: 100
               }
             }

--- a/gql/queries/FTVAEventDetail.gql
+++ b/gql/queries/FTVAEventDetail.gql
@@ -20,9 +20,13 @@ query FTVAEventDetail($slug: [String!]) {
     # CardMeta
     title: eventTitle
     guestSpeaker
-    tagLabels: ftvaEventFilters {
+    ftvaScreeningFormatFilters {
+      id
       title
-      uri
+    }
+    ftvaEventTypeFilters {
+      title
+      id
     }
     introduction: ftvaEventIntroduction
 

--- a/gql/queries/FTVAEventSeriesDetail.gql
+++ b/gql/queries/FTVAEventSeriesDetail.gql
@@ -76,8 +76,13 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
       image: ftvaImage {
         ...Image
       }
-      tagLabels: ftvaEventFilters {
+      ftvaScreeningFormatFilters {
+        id
         title
+      }
+      ftvaEventTypeFilters {
+        title
+        id
       }
   }
   pastEvents: entries(section: "ftvaEvent", relatedToEntries: { section: "ftvaEventSeries", slug: $slug }, startDateWithTime: "< now", orderBy: "startDateWithTime DESC") {
@@ -92,8 +97,13 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
     image: ftvaImage {
       ...Image
     }
-    tagLabels: ftvaEventFilters {
+    ftvaScreeningFormatFilters {
+      id
       title
+    }
+    ftvaEventTypeFilters {
+      title
+      id
     }
   }
   otherSeriesOngoing: entries(section: "ftvaEventSeries", limit: 3, ongoing: true) {

--- a/gql/queries/FTVAEventSeriesDetail.gql
+++ b/gql/queries/FTVAEventSeriesDetail.gql
@@ -52,8 +52,13 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
       ftvaImage {
         ...Image
       }
-      ftvaEventFilters {
+      ftvaScreeningFormatFilters {
+        id
         title
+      }
+      ftvaEventTypeFilters {
+        title
+        id
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"nuxt-graphql-request": "^7.0.5",
 		"sass": "^1.66.1",
 		"ucla-library-design-tokens": "^5.27.2",
-		"ucla-library-website-components": "3.31.6"
+		"ucla-library-website-components": "3.33.0"
 	},
 	"engines": {
 		"pnpm": "^9.12.1"

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -25,6 +25,7 @@ const { data, error } = await useAsyncData(`events-detail-${route.params.slug}`,
   const data = await $graphql.default.request(FTVAEventDetail, { slug: route.params.slug })
   return data
 })
+
 if (error.value) {
   throw createError({
     ...error.value, statusMessage: 'Page not found.' + error.value, fatal: true
@@ -54,6 +55,10 @@ if (data.value.ftvaEvent && import.meta.prerender) {
 
 const page = ref(_get(data.value, 'ftvaEvent', {}))
 const series = ref(_get(data.value, 'ftvaEventSeries', {}))
+
+// console.log('data: ', data.value)
+// console.log('page data: ', page.value)
+// console.log('series data: ', series.value)
 
 watch(data, (newVal, oldVal) => {
   // console.log('In watch preview enabled, newVal, oldVal', newVal, oldVal)
@@ -125,6 +130,19 @@ const parsedFTVAEventScreeningDetails = computed(() => {
       image: obj.image && obj.image.length === 1 ? obj.image[0] : null, // craft data has an array, but component expects a single object for image
     }
   })
+})
+
+const parsedTagLabels = computed(() => {
+  if (!page.value.ftvaEventTypeFilters && !page.value.ftvaScreeningFormatFilters) {
+    return []
+  }
+
+  const parsedLabels = []
+
+  page.value.ftvaEventTypeFilters.forEach(obj => parsedLabels.push(obj.title))
+  page.value.ftvaScreeningFormatFilters.forEach(obj => parsedLabels.push(obj.title))
+
+  return parsedLabels
 })
 
 useHead({
@@ -221,7 +239,7 @@ useHead({
       <template #primaryMid>
         <CardMeta
           :guest-speaker="page?.guestSpeaker"
-          :tag-labels="page?.tagLabels"
+          :tag-labels="parsedTagLabels"
           :introduction="page?.introduction"
         />
         <RichText
@@ -271,10 +289,7 @@ useHead({
   </main>
 </template>
 
-<style
-  lang="scss"
-  scoped
->
+<style lang="scss" scoped>
 // PAGE STYLES
 .page-event-detail {
   position: relative;

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -56,10 +56,6 @@ if (data.value.ftvaEvent && import.meta.prerender) {
 const page = ref(_get(data.value, 'ftvaEvent', {}))
 const series = ref(_get(data.value, 'ftvaEventSeries', {}))
 
-// console.log('data: ', data.value)
-// console.log('page data: ', page.value)
-// console.log('series data: ', series.value)
-
 watch(data, (newVal, oldVal) => {
   // console.log('In watch preview enabled, newVal, oldVal', newVal, oldVal)
   page.value = _get(newVal, 'ftvaEvent', {})
@@ -138,9 +134,16 @@ const parsedTagLabels = computed(() => {
   }
 
   const parsedLabels = []
+  const typeFilters = page.value.ftvaEventTypeFilters
+  const formatFilters = page.value.ftvaScreeningFormatFilters
 
-  page.value.ftvaEventTypeFilters.forEach(obj => parsedLabels.push(obj.title))
-  page.value.ftvaScreeningFormatFilters.forEach(obj => parsedLabels.push(obj.title))
+  if (typeFilters.length) {
+    typeFilters.forEach(obj => parsedLabels.push(obj.title))
+  }
+
+  if (formatFilters.length) {
+    formatFilters.forEach(obj => parsedLabels.push(obj.title))
+  }
 
   return parsedLabels
 })

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -138,11 +138,11 @@ const parsedTagLabels = computed(() => {
   const formatFilters = page.value.ftvaScreeningFormatFilters
 
   if (typeFilters.length) {
-    typeFilters.forEach(obj => parsedLabels.push(obj.title))
+    typeFilters.forEach(obj => parsedLabels.push({ title: obj.title }))
   }
 
   if (formatFilters.length) {
-    formatFilters.forEach(obj => parsedLabels.push(obj.title))
+    formatFilters.forEach(obj => parsedLabels.push({ title: obj.title }))
   }
 
   return parsedLabels

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -47,9 +47,12 @@ const { indexFilters } = useIndexFilter()
 
 onMounted(async () => {
   await setFilters()
+
   const testFilters = {
-    'tagLabels.title.keyword': ['Guest speaker', '35mm']
+    'ftvaEventTypeFilters.title.keyword': ['Guest speaker', '35mm'],
+    'ftvaScreeningFormatFilters.title.keyword': ['DCP', 'Film'],
   }
+
   const esOutput = await indexFilters('ftvaEvent', testFilters, ['2000-03-08', '2029-03-08'], 'startDate', 'asc')
   console.log(esOutput.hits.total.value)
 })

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -51,7 +51,6 @@ if (data.value.ftvaEventSeries && import.meta.prerender) {
   }
 }
 
-// console.log('data: ', data.value)
 const page = ref(_get(data.value, 'ftvaEventSeries', {}))
 const upcomingEvents = ref(_get(data.value, 'upcomingEvents', {}))
 const pastEvents = ref(_get(data.value, 'pastEvents', {}))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^5.27.2
         version: 5.27.2
       ucla-library-website-components:
-        specifier: 3.31.6
-        version: 3.31.6(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))
+        specifier: 3.33.0
+        version: 3.33.0(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))
 
 packages:
 
@@ -4447,8 +4447,9 @@ packages:
   ucla-library-design-tokens@5.27.2:
     resolution: {integrity: sha512-+GgHevX1Fflu1uSAgT7otxzqLUuOAXaVKK9vKqTckSiSMxMs1dqBBXqA6+++HuPym2MazR0lSBHA8B53cfVk1Q==}
 
-  ucla-library-website-components@3.31.6:
-    resolution: {integrity: sha512-lIdcuuUqBOyiAgSlxDh/8AJE8PCIgogC1hR1gEHAT+y98hfka40tYDuFjxlMfZsRIXr3fAAqeav3WUtIq0CNRg==}
+  ucla-library-website-components@3.33.0:
+    resolution: {integrity: sha512-0SuLCyOuvSN4qRifxFI+OJ/5azoc4cJgLhQz4Ef/mo7IuL945pbSn+9HoN11f0SwKGOyT6LvDMub9CawY0V/WA==}
+    engines: {pnpm: ^9.12.1}
     peerDependencies:
       vue: ^3.5.12
 
@@ -9969,7 +9970,7 @@ snapshots:
 
   ucla-library-design-tokens@5.27.2: {}
 
-  ucla-library-website-components@3.31.6(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)):
+  ucla-library-website-components@3.33.0(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)):
     dependencies:
       '@vuepic/vue-datepicker': 8.8.1(vue@3.5.12(typescript@5.6.3))
       '@vueuse/components': 11.1.0(vue@3.5.12(typescript@5.6.3))


### PR DESCRIPTION
Connected to [APPS-3054](https://jira.library.ucla.edu/browse/APPS-3054)

**Page Updated:** 
- pages/events/[slug].vue
- pages/events/index.vue
- pages/series/[slug].vue

**Notes:**
- Updated event query and aggregator composable to account for two sets of filters: Event Type and Screening Format
- Created/updated computed properties to parse tagLabels from the new filters

**Previews:**

_Event Detail_
![event-detail](https://github.com/user-attachments/assets/636ecd3f-702f-4691-93cd-238f10297c48)

_Series Detail_
![series-detail](https://github.com/user-attachments/assets/7779bc5a-5132-45b6-8f80-2c8021e7ebc3)


**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I assigned this PR to someone to review
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~



[APPS-3054]: https://uclalibrary.atlassian.net/browse/APPS-3054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ