### PR TITLE
fix: APPS-3065 Refactor TagLabels Parsing Logic

### DIFF
--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -15,6 +15,7 @@ import removeTags from '../utils/removeTags'
 import { useContentIndexer } from '~/composables/useContentIndexer'
 
 // UTILS
+import { getEventFilterLabels } from '~/utils/getEventFilterLabels'
 
 const { $graphql } = useNuxtApp()
 
@@ -128,24 +129,11 @@ const parsedFTVAEventScreeningDetails = computed(() => {
   })
 })
 
+// Extract tag labels from event filters
 const parsedTagLabels = computed(() => {
-  if (!page.value.ftvaEventTypeFilters && !page.value.ftvaScreeningFormatFilters) {
-    return []
-  }
-
-  const parsedLabels = []
-  const typeFilters = page.value.ftvaEventTypeFilters
-  const formatFilters = page.value.ftvaScreeningFormatFilters
-
-  if (typeFilters.length) {
-    typeFilters.forEach(obj => parsedLabels.push({ title: obj.title }))
-  }
-
-  if (formatFilters.length) {
-    formatFilters.forEach(obj => parsedLabels.push({ title: obj.title }))
-  }
-
-  return parsedLabels
+  const eventObj = page.value
+  const parsedTagLabels = getEventFilterLabels(eventObj)
+  return parsedTagLabels
 })
 
 useHead({

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -56,6 +56,10 @@ if (data.value.ftvaEvent && import.meta.prerender) {
 const page = ref(_get(data.value, 'ftvaEvent', {}))
 const series = ref(_get(data.value, 'ftvaEventSeries', {}))
 
+// console.log('data: ', data.value)
+// console.log('page data: ', page.value)
+// console.log('series data: ', series.value)
+
 watch(data, (newVal, oldVal) => {
   // console.log('In watch preview enabled, newVal, oldVal', newVal, oldVal)
   page.value = _get(newVal, 'ftvaEvent', {})
@@ -134,16 +138,9 @@ const parsedTagLabels = computed(() => {
   }
 
   const parsedLabels = []
-  const typeFilters = page.value.ftvaEventTypeFilters
-  const formatFilters = page.value.ftvaScreeningFormatFilters
 
-  if (typeFilters.length) {
-    typeFilters.forEach(obj => parsedLabels.push({ title: obj.title }))
-  }
-
-  if (formatFilters.length) {
-    formatFilters.forEach(obj => parsedLabels.push({ title: obj.title }))
-  }
+  page.value.ftvaEventTypeFilters.forEach(obj => parsedLabels.push(obj.title))
+  page.value.ftvaScreeningFormatFilters.forEach(obj => parsedLabels.push(obj.title))
 
   return parsedLabels
 })

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -56,10 +56,6 @@ if (data.value.ftvaEvent && import.meta.prerender) {
 const page = ref(_get(data.value, 'ftvaEvent', {}))
 const series = ref(_get(data.value, 'ftvaEventSeries', {}))
 
-// console.log('data: ', data.value)
-// console.log('page data: ', page.value)
-// console.log('series data: ', series.value)
-
 watch(data, (newVal, oldVal) => {
   // console.log('In watch preview enabled, newVal, oldVal', newVal, oldVal)
   page.value = _get(newVal, 'ftvaEvent', {})
@@ -138,9 +134,16 @@ const parsedTagLabels = computed(() => {
   }
 
   const parsedLabels = []
+  const typeFilters = page.value.ftvaEventTypeFilters
+  const formatFilters = page.value.ftvaScreeningFormatFilters
 
-  page.value.ftvaEventTypeFilters.forEach(obj => parsedLabels.push(obj.title))
-  page.value.ftvaScreeningFormatFilters.forEach(obj => parsedLabels.push(obj.title))
+  if (typeFilters.length) {
+    typeFilters.forEach(obj => parsedLabels.push(obj.title))
+  }
+
+  if (formatFilters.length) {
+    formatFilters.forEach(obj => parsedLabels.push(obj.title))
+  }
 
   return parsedLabels
 })

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -138,11 +138,11 @@ const parsedTagLabels = computed(() => {
   const formatFilters = page.value.ftvaScreeningFormatFilters
 
   if (typeFilters.length) {
-    typeFilters.forEach(obj => parsedLabels.push(obj.title))
+    typeFilters.forEach(obj => parsedLabels.push({ title: obj.title }))
   }
 
   if (formatFilters.length) {
-    formatFilters.forEach(obj => parsedLabels.push(obj.title))
+    formatFilters.forEach(obj => parsedLabels.push({ title: obj.title }))
   }
 
   return parsedLabels

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -51,7 +51,6 @@ if (data.value.ftvaEventSeries && import.meta.prerender) {
   }
 }
 
-// console.log('data: ', data.value)
 const page = ref(_get(data.value, 'ftvaEventSeries', {}))
 const upcomingEvents = ref(_get(data.value, 'upcomingEvents', {}))
 const pastEvents = ref(_get(data.value, 'pastEvents', {}))

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -51,6 +51,7 @@ if (data.value.ftvaEventSeries && import.meta.prerender) {
   }
 }
 
+// console.log('data: ', data.value)
 const page = ref(_get(data.value, 'ftvaEventSeries', {}))
 const upcomingEvents = ref(_get(data.value, 'upcomingEvents', {}))
 const pastEvents = ref(_get(data.value, 'pastEvents', {}))

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -10,6 +10,9 @@ import _get from 'lodash/get'
 // GQL
 import FTVAEventSeriesDetail from '../gql/queries/FTVAEventSeriesDetail.gql'
 
+// UTIL
+import { getEventFilterLabels } from '~/utils/getEventFilterLabels'
+
 // COMPOSABLE
 import { useContentIndexer } from '~/composables/useContentIndexer'
 import removeTags from '~/utils/removeTags'
@@ -98,7 +101,7 @@ const parsedUpcomingEvents = computed(() => {
 
   // Transform data
   return upcomingEvents.value.map((item, index) => {
-    const parsedTagLabels = getParsedTagLabels(item)
+    const parsedTagLabels = getEventFilterLabels(item)
 
     return {
       ...item,
@@ -116,7 +119,7 @@ const parsedPastEvents = computed(() => {
 
   // Transform data
   return pastEvents.value.map((item, index) => {
-    const parsedTagLabels = getParsedTagLabels(item)
+    const parsedTagLabels = getEventFilterLabels(item)
 
     return {
       ...item,
@@ -126,26 +129,6 @@ const parsedPastEvents = computed(() => {
     }
   })
 })
-
-function getParsedTagLabels(obj) {
-  if (!obj.ftvaEventTypeFilters && !obj.ftvaScreeningFormatFilters) {
-    return []
-  }
-
-  const parsedLabels = []
-  const typeFilters = obj.ftvaEventTypeFilters
-  const formatFilters = obj.ftvaScreeningFormatFilters
-
-  if (typeFilters.length) {
-    typeFilters.forEach(obj => parsedLabels.push({ title: obj.title }))
-  }
-
-  if (formatFilters.length) {
-    formatFilters.forEach(obj => parsedLabels.push({ title: obj.title }))
-  }
-
-  return parsedLabels
-}
 
 // If no Upcoming Events, set starting tab to Past Events
 const parsedInitialTabIndex = computed(() => {

--- a/utils/getEventFilterLabels.js
+++ b/utils/getEventFilterLabels.js
@@ -1,0 +1,28 @@
+/**
+ * Extract tag labels from FTVA filters (ftvaScreeningFormatFilters,
+ftvaEventTypeFilters) and return as a single array
+
+ * @param {Object}
+ * @returns {Array}
+ */
+
+export function getEventFilterLabels(obj) {
+  if (!obj.ftvaEventTypeFilters && !obj.ftvaScreeningFormatFilters) {
+    return []
+  }
+
+  const parsedTagLabels = []
+
+  const eventTypeFilters = obj.ftvaEventTypeFilters
+  const screeningFormatFilters = obj.ftvaScreeningFormatFilters
+
+  if (eventTypeFilters.length) {
+    eventTypeFilters.forEach(obj => parsedTagLabels.push({ title: obj.title }))
+  }
+
+  if (screeningFormatFilters.length) {
+    screeningFormatFilters.forEach(obj => parsedTagLabels.push({ title: obj.title }))
+  }
+
+  return parsedTagLabels
+}


### PR DESCRIPTION
Connected to [APPS-3065](https://jira.library.ucla.edu/browse/APPS-3065)

**Page Updated:** 
- pages/events/[slug].vue
- pages/series/[slug].vue

**Notes:**
- Extracted repeating/reused logic for parsing tagLabels into a utility function.

**Previews:**
- https://deploy-preview-69--test-ftva.netlify.app/events/the-pink-cloud-shorts-03-02-24/
- https://deploy-preview-69--test-ftva.netlify.app/series/the-films-of-michael-snow

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I assigned this PR to someone to review
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~


[APPS-3065]: https://uclalibrary.atlassian.net/browse/APPS-3065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ