### PR TITLE
chore: APPS-3088 add vuetify components for Calendar

### DIFF
--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -2,12 +2,13 @@
 import 'vuetify/styles' // Import Vuetify styles
 import { createVuetify } from 'vuetify'
 import { VCalendar } from 'vuetify/labs/VCalendar' // Import VCalendar
+import { VCard, VList, VListItem, VMenu, VSheet } from 'vuetify/lib/components/index.mjs'
 import '@mdi/font/css/materialdesignicons.css' // Import Material Design Icons
 
 export default defineNuxtPlugin((nuxtApp) => {
   const vuetify = createVuetify({
     components: {
-      VCalendar,
+      VCalendar, VSheet, VMenu, VList, VCard, VListItem,
     },
   })
 


### PR DESCRIPTION
Connected to [APPS-3088](https://jira.library.ucla.edu/browse/APPS-3088)

**Notes:**

Updated vuetify.ts configuration to import more Vuetify components, which are used as part of the Calendar

**Checklist:**

-   [X] I added github label for semantic versioning
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~
-   [ ] I assigned this PR to someone to review


[APPS-3088]: https://uclalibrary.atlassian.net/browse/APPS-3088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ