### PR TITLE
feat: APPS-3050 Add a new gql query on the page for title, summary

### DIFF
--- a/gql/queries/FTVAEventList.gql
+++ b/gql/queries/FTVAEventList.gql
@@ -1,6 +1,10 @@
 # import "../gql/fragments/Image.gql"
 
 query FTVAEventList {
+  entry(section: ["ftvaListingEvents"]) {
+    titleGeneral
+    summary
+  }
   entries(section: ["ftvaEvent"], orderBy: "postDate") {
     typeHandle
     id

--- a/gql/queries/FTVAEventList.gql
+++ b/gql/queries/FTVAEventList.gql
@@ -5,25 +5,4 @@ query FTVAEventList {
     titleGeneral
     summary
   }
-  entries(section: ["ftvaEvent"], orderBy: "postDate") {
-    typeHandle
-    id
-    title: eventTitle
-    to: uri
-    # image: ftvaImage {
-    #  ...Image
-    # }
-    startDateWithTime
-      @formatDateTime(
-        format: "Y-m-d\\TH:i"
-        timezone: "America/Los_Angeles"
-      )
-    startDate: startDateWithTime @formatDateTime(format: "Y-m-d\\TH:i:s", timezone: "America/Los_Angeles")
-    startTime: startDateWithTime @formatDateTime(format: "Y-m-d\\TH:i:s", timezone: "America/Los_Angeles")
-
-    ftvaEventFilters {
-      title
-      uri
-    }
-  }
 }

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -231,7 +231,7 @@ onMounted(async () => {
     // console.log('newWidth', newWidth)
     isMobile.value = newWidth <= 750
   },
-    { immediate: true })
+  { immediate: true })
   await setFilters()
   const { allEvents } = useDateFilterQuery()
   /* const testFilters = {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -7,35 +7,32 @@ import _get from 'lodash/get'
 import { parseISO } from 'date-fns'
 
 // UTILS
+import FTVAEventList from '../gql/queries/FTVAEventList.gql'
 import parseFilters from '@/utils/parseFilters'
 import { getEventFilterLabels } from '~/utils/getEventFilterLabels'
 
 // GQL
-// TODO Add new query to fetch title and summary for this template from Craft singles check ticket APPS-3050
-
-/* const { $graphql } = useNuxtApp()
-
+const { $graphql } = useNuxtApp()
 const { data, error } = await useAsyncData('event-list', async () => {
   const data = await $graphql.default.request(FTVAEventList)
   return data
 })
-
 if (error.value) {
   throw createError({
     ...error.value, statusMessage: 'Page not found.' + error.value, fatal: true
   })
 }
 
-if (!data.value.entries) {
+if (!data.value.entry || !data.value.entries) {
   // console.log('no data')
   throw createError({
     statusCode: 404,
     statusMessage: 'Page Not Found',
     fatal: true
   })
-} */
-
-// const page = ref(_get(data.value, 'entries[0]', {}))
+}
+const heading = ref(_get(data.value, 'entry', {}))
+const page = ref(_get(data.value, 'entries[0]', {})) // TODO map this to events?
 
 const events = ref([]) // Add typescript
 const userFilterSelection = ref({}) // Add typescript and should we have separate filters ref for date and eventFilters
@@ -272,8 +269,8 @@ function toggleCode() {
     class="page page-events"
   >
     <div class="one-column">
-      <h2> Craft Title Upcoming Events</h2>
-      <div> Craft Summary Text </div>
+      <h2>{{ heading.generalTitle }}</h2>
+      <div>{{ heading.summary }}</div>
     </div>
 
     <div>

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -24,7 +24,7 @@ if (error.value) {
   })
 }
 
-if (!data.value.entry || !data.value.entries) {
+if (!data.value.entry) {
   // console.log('no data')
   throw createError({
     statusCode: 404,
@@ -33,7 +33,6 @@ if (!data.value.entry || !data.value.entries) {
   })
 }
 const heading = ref(_get(data.value, 'entry', {}))
-const page = ref(_get(data.value, 'entries[0]', {})) // TODO map this to events?
 
 // TYPES
 interface FilterItem {
@@ -232,7 +231,7 @@ onMounted(async () => {
     // console.log('newWidth', newWidth)
     isMobile.value = newWidth <= 750
   },
-  { immediate: true })
+    { immediate: true })
   await setFilters()
   const { allEvents } = useDateFilterQuery()
   /* const testFilters = {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -269,7 +269,7 @@ function toggleCode() {
     class="page page-events"
   >
     <div class="one-column">
-      <h2>{{ heading.generalTitle }}</h2>
+      <h2>{{ heading.titleGeneral }}</h2>
       <div>{{ heading.summary }}</div>
     </div>
 


### PR DESCRIPTION
Connected to [APPS-3050](https://jira.library.ucla.edu/browse/APPS-3050)

**Page/Pages Created/updated:** /events/index.vue & GQL

**Notes:**

I added the query to the existing query for the event listing page. I displayed the text in the page to verify it was there, but it has not been formatted or styled in any way yet. 

**Time Report:**

This took me 5 hours to build & test this.

**Checklist:**

-   [X] I added github label for semantic versioning
-   ~~[] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   [X] I added notes above about how long it took to build this component
-   ~~[ ] UX has reviewed this PR~~
-   [ ] I assigned this PR to someone to review


[APPS-3050]: https://uclalibrary.atlassian.net/browse/APPS-3050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ