### PR TITLE
feat: APPS-3114   Add ongoing to the current and ongoing query on eventSeries page

### DIFF
--- a/composables/useEventSeriesListSearchFilter.js
+++ b/composables/useEventSeriesListSearchFilter.js
@@ -90,18 +90,26 @@ async function currentEventSeriesQuery(
             filter: [
               {
                 term: {
-                  'sectionHandle.keyword': 'ftvaEventSeries'
-                }
+                  'sectionHandle.keyword': 'ftvaEventSeries',
+                },
+              },
+            ],
+            should: [
+              {
+                term: {
+                  ongoing: true,
+                },
               },
               {
                 range: {
-                  startDate: {
-                    gte: 'now/d-8h'
-                  }
-                }
-              }
-            ]
-          },
+                  endDate: {
+                    gte: 'now/d-8h',
+                  },
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          }
         },
         ...parseSort(sort, orderBy),
       }),


### PR DESCRIPTION
Connected to [APPS-3114](https://jira.library.ucla.edu/browse/APPS-3114)

Adds the ongoing records

<img width="1225" alt="Screenshot 2024-12-20 at 11 16 11 AM" src="https://github.com/user-attachments/assets/eaecc09d-17fe-41f6-996b-3cdd20d50f6d" />


[APPS-3114]: https://uclalibrary.atlassian.net/browse/APPS-3114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ