### PR TITLE
fix: APPS-3044 Remove image tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "nuxt-graphql-request": "^7.0.5",
     "sass": "^1.66.1",
     "ucla-library-design-tokens": "^5.28.0",
-    "ucla-library-website-components": "3.43.5"
+    "ucla-library-website-components": "3.43.6"
   },
   "engines": {
     "pnpm": "^9.12.1"

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -26,6 +26,7 @@ const { data, error } = await useAsyncData(`collections-detail-${route.params.sl
   const data = await $graphql.default.request(FTVACollectionDetail, { slug: route.params.slug })
   return data
 })
+
 if (error.value) {
   throw createError({
     ...error.value, statusMessage: 'Page not found.' + error.value, fatal: true
@@ -68,6 +69,7 @@ const parsedImage = computed(() => {
   }
   return page.value.imageCarousel
 })
+
 // Transform data for Carousel
 const parsedCarouselData = computed(() => {
   // map image to item, map creditText to credit
@@ -78,12 +80,14 @@ const parsedCarouselData = computed(() => {
     }
   })
 })
+
 // Map icon names to svg names for infoBlock
 const parsedInfoBlockIconLookup = {
   'icon-download': 'svg-call-to-action-ftva-pdf',
   'icon-info': 'svg-call-to-action-ftva-info',
   'icon-external-link': 'svg-call-to-action-ftva-external-link-dark'
 }
+
 const parsedInfoBlock = computed(() => {
   // fail gracefully if data does not exist (server-side)
   if (!page.value.infoBlock || page.value.infoBlock.length === 0) {
@@ -97,6 +101,7 @@ const parsedInfoBlock = computed(() => {
     }
   })
 })
+
 const parsedRelatedCollectionsHeader = computed(() => {
   // fail gracefully if data does not exist (server-side)
   if (!page.value.sectionTitle) {
@@ -104,6 +109,7 @@ const parsedRelatedCollectionsHeader = computed(() => {
   }
   return page.value.sectionTitle ? page.value.sectionTitle : 'Related Collections'
 })
+
 const parsedRelatedCollections = computed(() => {
   // fail gracefully if data does not exist (server-side)
   if (!page.value.ftvaRelatedCollections) {
@@ -115,23 +121,31 @@ const parsedRelatedCollections = computed(() => {
       ...item,
       to: `/${item.uri}`,
       category: 'collection',
-      bylineOne: item.richText,
+      // Remove image tags
+      bylineOne: item.richText.replace(/<img.*?>/ig, ''),
       image: item.ftvaImage && item.ftvaImage.length > 0 ? item.ftvaImage[0] : null,
     }
   })
   return relatedCollections
 })
+// console.log('related: ', parsedRelatedCollections.value)
+
 const parsedRelatedCollectionsText = computed(() => {
   // TODO does this fail gracefully?
   const text = _get(page.value, 'viewAllSectionLink[0].viewAllText', '')
   return text || 'View All'
 })
+
 // TODO goes to /collections/[uri] - is this correct check with UX?
 const parsedRelatedCollectionsLink = computed(() => {
   // TODO does this fail gracefully?
   const link = _get(page.value, 'viewAllSectionLink[0].viewAllLink[0].uri', '')
   return link || '/collections'
 })
+
+function stripImageTags(str) {
+
+}
 
 useHead({
   title: page.value ? page.value.title : '... loading',
@@ -259,10 +273,7 @@ useHead({
   </main>
 </template>
 
-<style
-  lang="scss"
-  scoped
->
+<style lang="scss" scoped>
 .page-collection-detail {
   position: relative;
 

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -302,6 +302,19 @@ useHead({
 
   .related-collections-card {
     :deep(.card-meta) {
+      display: grid;
+      grid-template-rows: auto 1fr 1fr;
+      row-gap: 8px;
+
+      .category,
+      .title,
+      .byline-group {
+        margin: 0;
+      }
+
+      .title {
+        @include truncate(2);
+      }
 
       .byline-group {
         position: static;

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -121,14 +121,13 @@ const parsedRelatedCollections = computed(() => {
       ...item,
       to: `/${item.uri}`,
       category: 'collection',
-      // Remove image tags
+      // Remove image tags inside byline rich text
       bylineOne: item.richText.replace(/<img.*?>/ig, ''),
       image: item.ftvaImage && item.ftvaImage.length > 0 ? item.ftvaImage[0] : null,
     }
   })
   return relatedCollections
 })
-// console.log('related: ', parsedRelatedCollections.value)
 
 const parsedRelatedCollectionsText = computed(() => {
   // TODO does this fail gracefully?
@@ -302,9 +301,17 @@ useHead({
   }
 
   .related-collections-card {
+    :deep(.card-meta) {
+
+      .byline-group {
+        position: static;
+      }
+    }
+
     :deep(.byline-group) {
       @include truncate(2);
     }
+
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: ^5.28.0
         version: 5.28.0
       ucla-library-website-components:
-        specifier: 3.43.5
-        version: 3.43.5(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
+        specifier: 3.43.6
+        version: 3.43.6(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
 
 packages:
 
@@ -4459,8 +4459,8 @@ packages:
   ucla-library-design-tokens@5.28.0:
     resolution: {integrity: sha512-qgxGlK3/m0VwYGumzLZTTB/ae03DY41+80vFhm4+gukzh8XiqUsN71cg3ijk23Dl9awyicoELbRgnUV4nj3e0g==}
 
-  ucla-library-website-components@3.43.5:
-    resolution: {integrity: sha512-Utf2Mk9FfjHipRuqv+nks0P6Rc7/kyC6waToiB14szOUyrooO+7Hzq6ZMTjlwghzA+gcgTX4VVtsetLojP3XtQ==}
+  ucla-library-website-components@3.43.6:
+    resolution: {integrity: sha512-HMMHhbnQk735EU0SaUYMPRjP6SqYovurA/s8btImF1QqmAQbyRJ7WbiF1udVb946b4FsQtOXGiFUm3xpEgh4nw==}
     engines: {pnpm: ^9.12.1}
     peerDependencies:
       vue: ^3.5.12
@@ -10001,7 +10001,7 @@ snapshots:
 
   ucla-library-design-tokens@5.28.0: {}
 
-  ucla-library-website-components@3.43.5(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))):
+  ucla-library-website-components@3.43.6(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))):
     dependencies:
       '@vuepic/vue-datepicker': 8.8.1(vue@3.5.12(typescript@5.6.3))
       '@vueuse/components': 11.3.0(vue@3.5.12(typescript@5.6.3))


### PR DESCRIPTION
Connected to [APPS-3044](https://jira.library.ucla.edu/browse/APPS-3044)

**Page updated:** /pages/collections/[slug].vue

https://deploy-preview-91--test-ftva.netlify.app/collections/test-get-used-to-it/

**Notes:**
- Stripped out image tags in rich text description used for collection card byline
- Fixed CSS to remove overall text overflow in the collection cards

**Local Previews:**
_Before_
![collection-cad-rich-text-image-embed--before](https://github.com/user-attachments/assets/c2e18ba7-242a-42ce-92c2-791005ce7993)

_After_
![collection-cad-rich-text-image-embed--after](https://github.com/user-attachments/assets/4674dc1b-f217-41bd-8e9c-4faed6413aaa)

**Checklist:**

-   [x] I added github label for semantic versioning
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   [x] UX has reviewed this PR
-   [x] I requested a PR review from the Dev team


[APPS-3044]: https://uclalibrary.atlassian.net/browse/APPS-3044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ