### PR TITLE
fix: APPS-3084 Make date and event filters sticky

### DIFF
--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -714,6 +714,10 @@ const parseFirstEventMonth = computed(() => {
         width: 100%;
       }
 
+      .dp__input {
+        height: 52px;
+      }
+
       .custom-header {
         font-size: 20px;
 
@@ -731,7 +735,7 @@ const parseFirstEventMonth = computed(() => {
 
     :deep(.mobile-button) {
       min-width: unset;
-      height: 59px;
+      height: 52px;
     }
 
     :deep(.button-dropdown-modal-wrapper.is-expanded) {
@@ -791,10 +795,12 @@ const parseFirstEventMonth = computed(() => {
     .mobile-filters-outer-wrapper {
       margin-bottom: 20px;
 
-      &.is-sticky position: sticky;
-      top: 65px;
-      z-index: 100;
-      background-color: var(--pale-blue);
+      &.is-sticky {
+        position: sticky;
+        top: 65px;
+        z-index: 100;
+        background-color: var(--pale-blue);
+      }
     }
 
     .date-filter {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -460,9 +460,8 @@ function applyChangesToSearch() {
 
 function handleFilterUpdate(updatedFilters) {
   allFilters.value = updatedFilters
-  console.log('Filters updated:', allFilters.value)
+  // console.log('Filters updated:', allFilters.value)
 }
-// console.log('Filters updated:', Object.keys(allFilters.value).length)
 
 const parseViewSelection = computed(() => {
   return userViewSelection.value === 'list' ? 0 : 1

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -622,6 +622,12 @@ const parseFirstEventMonth = computed(() => {
 </template>
 
 <style lang='scss' scoped>
+@mixin sticky {
+  position: sticky;
+  top: 65px;
+  z-index: 100;
+}
+
 :deep(.button-dropdown-modal-wrapper.is-expanded) {
   z-index: 1000;
 }
@@ -660,6 +666,7 @@ const parseFirstEventMonth = computed(() => {
     justify-content: space-between;
     width: 100%;
     margin-bottom: 20px;
+    @include sticky;
 
     .filters {
       flex-basis: 65%;
@@ -757,6 +764,10 @@ const parseFirstEventMonth = computed(() => {
   }
 
   @media #{$medium} {
+    .filters-wrapper {
+      @include sticky;
+    }
+
     .date-filter {
       :deep(.vue-date-picker) {
         .dp__outer_menu_wrap.dp--menu-wrapper {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -796,7 +796,7 @@ const parseFirstEventMonth = computed(() => {
 
   @media #{$medium} {
     .mobile-filters-outer-wrapper {
-      margin-bottom: 20px;
+      padding-bottom: 20px;
 
       &.is-sticky {
         position: sticky;

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -105,7 +105,7 @@ watch([width, bottom], ([newWidth, newBottom]) => {
   }
 
   // When bottom of SectionTeaserList hits the header-sticky bar, unstick the filters
-  if ((isMobile.value && bottom.value <= 150)) {
+  if ((isMobile.value && bottom.value <= 250)) {
     makeFiltersSticky.value = false
   } else {
     makeFiltersSticky.value = true
@@ -489,104 +489,104 @@ const parseFirstEventMonth = computed(() => {
       />
 
       <SectionWrapper theme="paleblue">
-        <div
-          class="sticky-wrapper"
-          :class="{ sticky: makeFiltersSticky }"
+        <TabList
+          v-if="!isMobile"
+          alignment="right"
+          :initial-tab="parseViewSelection"
         >
-          <TabList
-            v-if="!isMobile"
-            alignment="right"
-            :initial-tab="parseViewSelection"
+          <template #filters>
+            <div class="filters-wrapper">
+              <date-filter
+                :key="dateListDateFilter"
+                :event-dates="dateListDateFilter"
+                :initial-dates="parsedInitialDates"
+                data-test="date-filter"
+                @input-selected="applyDateFilterSelectionToRouteURL"
+              />
+              <filters-dropdown
+                v-model:selected-filters="userFilterSelection"
+                :filter-groups="searchFilters"
+                data-test="filters-dropdown"
+                @update-display="applyEventFilterSelectionToRouteURL"
+              />
+            </div>
+          </template>
+
+          <TabItem
+            title="List View"
+            class="tab-content"
+            data-test="list-view"
           >
-            <template #filters>
-              <div class="filters-wrapper">
-                <date-filter
-                  :key="dateListDateFilter"
-                  :event-dates="dateListDateFilter"
-                  :initial-dates="parsedInitialDates"
-                  data-test="date-filter"
-                  @input-selected="applyDateFilterSelectionToRouteURL"
-                />
-                <filters-dropdown
-                  v-model:selected-filters="userFilterSelection"
-                  :filter-groups="searchFilters"
-                  data-test="filters-dropdown"
-                  @update-display="applyEventFilterSelectionToRouteURL"
+            <template v-if="parsedEvents && parsedEvents.length > 0">
+              <SectionTeaserList
+                :items="parsedEvents"
+                component-name="BlockCardThreeColumn"
+                :n-shown="10"
+                class="tabbed-event-list"
+                data-test="tabbed-content"
+              />
+
+              <section-pagination
+                v-if="totalPages !== 1"
+                :pages="totalPages"
+                :initial-current-page="currentPage"
+              />
+            </template>
+            <template v-else>
+              <p
+                v-if="noResultsFound"
+                class="empty-tab"
+              >
+                There are no upcoming events WITH THE FILTERS YOU SELECTED
+              </p>
+              <p
+                v-else
+                class="empty-tab"
+              >
+                Data loading in progress ...
+              </p>
+            </template>
+          </TabItem>
+
+          <TabItem
+            title="Calendar View"
+            class="tab-content"
+            data-test="calendar-view"
+          >
+            <template v-if="parsedEvents && parsedEvents.length > 0">
+              <div style="display: flex;justify-content: center;">
+                <base-calendar
+                  :events="parsedEvents"
+                  :first-event-month="parseFirstEventMonth"
                 />
               </div>
+              <br>
+              <br>
             </template>
-
-            <TabItem
-              title="List View"
-              class="tab-content"
-              data-test="list-view"
-            >
-              <template v-if="parsedEvents && parsedEvents.length > 0">
-                <SectionTeaserList
-                  :items="parsedEvents"
-                  component-name="BlockCardThreeColumn"
-                  :n-shown="10"
-                  class="tabbed-event-list"
-                  data-test="tabbed-content"
-                />
-
-                <section-pagination
-                  v-if="totalPages !== 1"
-                  :pages="totalPages"
-                  :initial-current-page="currentPage"
-                />
-              </template>
-              <template v-else>
-                <p
-                  v-if="noResultsFound"
-                  class="empty-tab"
-                >
-                  There are no upcoming events WITH THE FILTERS YOU SELECTED
-                </p>
-                <p
-                  v-else
-                  class="empty-tab"
-                >
-                  Data loading in progress ...
-                </p>
-              </template>
-            </TabItem>
-
-            <TabItem
-              title="Calendar View"
-              class="tab-content"
-              data-test="calendar-view"
-            >
-              <template v-if="parsedEvents && parsedEvents.length > 0">
-                <div style="display: flex;justify-content: center;">
-                  <base-calendar
-                    :events="parsedEvents"
-                    :first-event-month="parseFirstEventMonth"
-                  />
-                </div>
-                <br>
-                <br>
-              </template>
-              <template v-else>
-                <p
-                  v-if="noResultsFound"
-                  class="empty-tab"
-                >
-                  There are no events found
-                </p>
-                <p
-                  v-else
-                  class="empty-tab"
-                >
-                  Data loading in progress ...
-                </p>
-              </template>
-            </TabItem>
-          </TabList>
+            <template v-else>
+              <p
+                v-if="noResultsFound"
+                class="empty-tab"
+              >
+                There are no events found
+              </p>
+              <p
+                v-else
+                class="empty-tab"
+              >
+                Data loading in progress ...
+              </p>
+            </template>
+          </TabItem>
+        </TabList>
+        <div
+          v-else
+          ref="el"
+          class="mobile-container"
+        >
           <div
-            v-else
-            ref="el"
-            class="mobile-container"
+            class="mobile-filters-outer-wrapper"
+            :class="{ 'is-sticky': makeFiltersSticky }"
           >
             <div class="filters-wrapper">
               <date-filter
@@ -609,29 +609,29 @@ const parseFirstEventMonth = computed(() => {
               @update:filters="handleFilterUpdate"
               @remove-selected="applyChangesToSearch"
             />
-            <SectionTeaserList
-              v-if="parsedEvents && parsedEvents.length > 0"
-              ref="sectionTeaserListElem"
-              :items="parsedEvents"
-              component-name="BlockCardThreeColumn"
-              :n-shown="events.length"
-              class="tabbed-event-list"
-              data-test="tabbed-content"
-            />
-            <div v-else>
-              <p
-                v-if="noResultsFound"
-                class="empty-tab"
-              >
-                There are no events found
-              </p>
-              <p
-                v-else
-                class="empty-tab"
-              >
-                Data loading in progress ...
-              </p>
-            </div>
+          </div>
+          <SectionTeaserList
+            v-if="parsedEvents && parsedEvents.length > 0"
+            ref="sectionTeaserListElem"
+            :items="parsedEvents"
+            component-name="BlockCardThreeColumn"
+            :n-shown="events.length"
+            class="tabbed-event-list"
+            data-test="tabbed-content"
+          />
+          <div v-else>
+            <p
+              v-if="noResultsFound"
+              class="empty-tab"
+            >
+              There are no events found
+            </p>
+            <p
+              v-else
+              class="empty-tab"
+            >
+              Data loading in progress ...
+            </p>
           </div>
         </div>
       </SectionWrapper>
@@ -640,12 +640,6 @@ const parseFirstEventMonth = computed(() => {
 </template>
 
 <style lang='scss' scoped>
-@mixin stickyFilters {
-  position: sticky;
-  top: 65px;
-  z-index: 100;
-}
-
 :deep(.button-dropdown-modal-wrapper.is-expanded) {
   z-index: 1000;
 }
@@ -667,10 +661,6 @@ const parseFirstEventMonth = computed(() => {
     width: 100%;
     background-color: var(--pale-blue);
     margin: 0 auto;
-  }
-
-  .sticky-wrapper {
-    max-width: var(--ftva-container-max-width);
   }
 
   :deep(.tab-list-body) {
@@ -787,9 +777,17 @@ const parseFirstEventMonth = computed(() => {
   }
 
   @media #{$medium} {
-    .sticky-wrapper.sticky {
-      .filters-wrapper {
-        @include stickyFilters;
+    .mobile-filters-outer-wrapper.is-sticky {
+      position: sticky;
+      top: 65px;
+      z-index: 100;
+      background-color: var(--pale-blue);
+
+      .mobile-remove-filters {
+        margin-top: 0;
+        margin-bottom: 0;
+        padding-top: 20px;
+        padding-bottom: 20px;
       }
     }
 

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -509,6 +509,12 @@ const parseFirstEventMonth = computed(() => {
                 @update-display="applyEventFilterSelectionToRouteURL"
               />
             </div>
+            <section-remove-search-filter
+              :filters="allFilters"
+              class="remove-filters"
+              @update:filters="handleFilterUpdate"
+              @remove-selected="applyChangesToSearch"
+            />
           </template>
 
           <TabItem
@@ -604,7 +610,7 @@ const parseFirstEventMonth = computed(() => {
             </div>
             <section-remove-search-filter
               :filters="allFilters"
-              class="mobile-remove-filters"
+              class="remove-filters"
               @update:filters="handleFilterUpdate"
               @remove-selected="applyChangesToSearch"
             />
@@ -662,15 +668,12 @@ const parseFirstEventMonth = computed(() => {
     margin: 0 auto;
   }
 
-  :deep(.tab-list-body) {
-    background: none;
+  :deep(.tab-list-header) {
+    align-self: self-start;
   }
 
-  :deep(.section-pagination) {
-    /* TODO Move this to ftva sectionwrapper.theme.paleblue scss file */
-    background-color: white;
-    max-width: unset;
-    padding: 2.5%;
+  :deep(.tab-list-body) {
+    background: none;
   }
 
   :deep(.tab-list.right) {
@@ -733,6 +736,12 @@ const parseFirstEventMonth = computed(() => {
     }
   }
 
+  .remove-filters {
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-top: 20px;
+  }
+
   .tab-content {
     min-height: 200px;
     background-color: white;
@@ -747,11 +756,6 @@ const parseFirstEventMonth = computed(() => {
     }
   }
 
-  .mobile-remove-filters {
-    margin-top: 20px;
-    margin-bottom: 20px;
-  }
-
   :deep(.base-calendar) {
     max-width: 1000px;
     padding-top: 32px;
@@ -759,6 +763,13 @@ const parseFirstEventMonth = computed(() => {
     .v-calendar-header {
       margin-bottom: 14px;
     }
+  }
+
+  :deep(.section-pagination) {
+    /* TODO Move this to ftva sectionwrapper.theme.paleblue scss file */
+    background-color: white;
+    max-width: unset;
+    padding: 2.5%;
   }
 
   @media(max-width: 1200px) {
@@ -780,10 +791,7 @@ const parseFirstEventMonth = computed(() => {
       z-index: 100;
       background-color: var(--pale-blue);
 
-      .mobile-remove-filters {
-        margin-top: 0;
-        margin-bottom: 0;
-        padding-top: 20px;
+      .remove-filters {
         padding-bottom: 20px;
       }
     }

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -460,8 +460,9 @@ function applyChangesToSearch() {
 
 function handleFilterUpdate(updatedFilters) {
   allFilters.value = updatedFilters
-  // console.log('Filters updated:', allFilters.value)
+  console.log('Filters updated:', allFilters.value)
 }
+// console.log('Filters updated:', Object.keys(allFilters.value).length)
 
 const parseViewSelection = computed(() => {
   return userViewSelection.value === 'list' ? 0 : 1
@@ -511,6 +512,7 @@ const parseFirstEventMonth = computed(() => {
               />
             </div>
             <section-remove-search-filter
+              v-if="Object.keys(allFilters).length > 0"
               :filters="allFilters"
               class="remove-filters"
               @update:filters="handleFilterUpdate"
@@ -610,6 +612,7 @@ const parseFirstEventMonth = computed(() => {
               />
             </div>
             <section-remove-search-filter
+              v-if="Object.keys(allFilters).length > 0"
               :filters="allFilters"
               class="remove-filters"
               @update:filters="handleFilterUpdate"

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -665,8 +665,6 @@ const parseFirstEventMonth = computed(() => {
 
   :deep(.tab-list-body) {
     background: none;
-    padding-left: 0;
-    padding-right: 0;
   }
 
   :deep(.section-pagination) {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -87,7 +87,7 @@ const noResultsFound = ref<boolean>(false)
 const isLoading = ref<boolean>(false)
 const isMobile = ref<boolean>(false)
 const hasMore = ref(true) // Flag to control infinite scroll
-const sectionTeaserListElem = ref(null) // Intersection target to unstick filters
+const sectionTeaserListElem = ref(null) // Element intersection target to unstick filters
 const makeFiltersSticky = ref(true)
 
 // Window Size Handling
@@ -104,7 +104,8 @@ watch([width, bottom], ([newWidth, newBottom]) => {
     handleScreenTransition()
   }
 
-  // When bottom of SectionTeaserList hits the header-sticky bar, unstick the filters
+  /* On mobile, when bottom of SectionTeaserList is less than 250px away
+  from the top edge of the viewport, unstick the filters */
   if ((isMobile.value && bottom.value <= 250)) {
     makeFiltersSticky.value = false
   } else {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -627,7 +627,10 @@ const parseFirstEventMonth = computed(() => {
             class="tabbed-event-list"
             data-test="tabbed-content"
           />
-          <div v-else>
+          <div
+            v-else
+            class="tab-content"
+          >
             <p
               v-if="noResultsFound"
               class="empty-tab"

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -105,7 +105,7 @@ watch([width, bottom], ([newWidth, newBottom]) => {
   }
 
   // When bottom of SectionTeaserList hits the header-sticky bar, unstick the filters
-  if ((isMobile.value && bottom.value <= 150) || (bottom.value <= 65)) {
+  if ((isMobile.value && bottom.value <= 150)) {
     makeFiltersSticky.value = false
   } else {
     makeFiltersSticky.value = true
@@ -523,7 +523,6 @@ const parseFirstEventMonth = computed(() => {
             >
               <template v-if="parsedEvents && parsedEvents.length > 0">
                 <SectionTeaserList
-                  ref="sectionTeaserListElem"
                   :items="parsedEvents"
                   component-name="BlockCardThreeColumn"
                   :n-shown="10"
@@ -672,12 +671,6 @@ const parseFirstEventMonth = computed(() => {
 
   .sticky-wrapper {
     max-width: var(--ftva-container-max-width);
-
-    &.sticky {
-      :deep(.tab-list.right) {
-        @include stickyFilters;
-      }
-    }
   }
 
   :deep(.tab-list-body) {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -788,15 +788,13 @@ const parseFirstEventMonth = computed(() => {
   }
 
   @media #{$medium} {
-    .mobile-filters-outer-wrapper.is-sticky {
-      position: sticky;
+    .mobile-filters-outer-wrapper {
+      margin-bottom: 20px;
+
+      &.is-sticky position: sticky;
       top: 65px;
       z-index: 100;
       background-color: var(--pale-blue);
-
-      .remove-filters {
-        padding-bottom: 20px;
-      }
     }
 
     .date-filter {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -485,7 +485,6 @@ const parseFirstEventMonth = computed(() => {
         class="header"
         theme="paleblue"
         :section-title="heading.titleGeneral"
-        :section-summary="heading.summary"
       />
 
       <SectionWrapper theme="paleblue">


### PR DESCRIPTION
Connected to [APPS-3084](https://jira.library.ucla.edu/browse/APPS-3084)

**Page updated:** /pages/events/index.vue

**Notes:**
- Make date and event filters and pills sticky on mobile when user scrolls
- Remove filters' stickiness at the bottom of the page (mobile)
- Additional fixes/updates:
  - Remove page summary field/content (per UX)
  - Display pills on desktop when events are filtered (per UX)
  - Clear pills bar/row when filters are emptied
  - Update desktop filter button heights to match tab-toggle
  - Add class/styling for no-data-found text on mobile

**Checklist:**

-   [x] I added github label for semantic versioning
-   ~~[ ] I double checked it looks like the designs~~
-   [x] I completed any required mobile breakpoint styling
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   [x] UX has reviewed this PR
-   [x] I have requested a PR review from the Dev team


[APPS-3084]: https://uclalibrary.atlassian.net/browse/APPS-3084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ