### PR TITLE
feat: Apps-3092 gql LA rebellion

### DIFF
--- a/gql/queries/FTVALARebellionFilmmakersDetail.gql
+++ b/gql/queries/FTVALARebellionFilmmakersDetail.gql
@@ -6,8 +6,8 @@ query FTVALARebellionFilmmakersDetail($slug: [String!]) {
     typeHandle
     sectionHandle
     slug
-    uri
-
+    to: uri
+    richText
     nameFirst
     nameLast
 
@@ -24,19 +24,19 @@ query FTVALARebellionFilmmakersDetail($slug: [String!]) {
       }
     }
 
-    # sub query? 
-#     query test {
-#   entries(section: "vacancies", relatedToEntries({attributeHandle: "valueYouWant") {
-#     title
-#     ... on vacancies_vacancies_Entry {
-#       description
-#       organisation {
-#         title
-#         ... on organisations_organisations_Entry {
-#           organisationType
-#         }
-#       }
-#     }
-#   }
-# }
+    associatedFilms {
+      image {
+        ...Image
+      }
+      titleGeneral
+      description
+      roles
+      year
+      filmLink {
+        uri
+        slug
+      }
+    }
+
+  }
 }

--- a/gql/queries/FTVALARebellionFilmmakersDetail.gql
+++ b/gql/queries/FTVALARebellionFilmmakersDetail.gql
@@ -1,0 +1,42 @@
+#import "../gql/fragments/Image.gql"
+
+query FTVALARebellionFilmmakersDetail($slug: [String!]) {
+  ftvaLARebellionIndividual: entry(section: "ftvaLARebellionIndividual", slug: $slug) {
+    id
+    typeHandle
+    sectionHandle
+    slug
+    uri
+
+    nameFirst
+    nameLast
+
+    image: ftvaImage {
+      ...Image
+    }
+
+    imageCarousel {
+      ...on imageCarousel_imageCarousel_BlockType {
+        image {
+          ...Image
+        }
+        creditText
+      }
+    }
+
+    # sub query? 
+#     query test {
+#   entries(section: "vacancies", relatedToEntries({attributeHandle: "valueYouWant") {
+#     title
+#     ... on vacancies_vacancies_Entry {
+#       description
+#       organisation {
+#         title
+#         ... on organisations_organisations_Entry {
+#           organisationType
+#         }
+#       }
+#     }
+#   }
+# }
+}

--- a/pages/collections/la-rebellion/filmmakers/[slug].vue
+++ b/pages/collections/la-rebellion/filmmakers/[slug].vue
@@ -1,0 +1,271 @@
+<script setup>
+// COMPONENT RE-IMPORTS
+// TODO: remove when we have implemented component library as a module
+// https://nuxt.com/docs/guide/directory-structure/components#library-authors
+import { BlockEventDetail, BlockInfo, BlockTag, ButtonDropdown, CardMeta, DividerWayFinder, FlexibleMediaGalleryNewLightbox, NavBreadcrumb, ResponsiveImage, RichText, SectionScreeningDetails, SectionTeaserCard, SectionWrapper, TwoColLayoutWStickySideBar } from 'ucla-library-website-components'
+
+// HELPERS
+import _get from 'lodash/get'
+
+// GQL
+// import FTVAEventDetail from '../gql/queries/FTVAEventDetail.gql'
+
+// COMPOSABLE
+import removeTags from '../utils/removeTags'
+// import { useContentIndexer } from '~/composables/useContentIndexer'
+
+// UTILS
+// import { getEventFilterLabels } from '~/utils/getEventFilterLabels'
+
+const { $graphql } = useNuxtApp()
+
+const route = useRoute()
+
+// DATA
+const { data, error } = await useAsyncData(`events-detail-${route.params.slug}`, async () => {
+  const data = await $graphql.default.request(ftvaLARebellionIndividual, { slug: route.params.slug })
+  return data
+})
+
+if (error.value) {
+  throw createError({
+    ...error.value, statusMessage: 'Page not found.' + error.value, fatal: true
+  })
+}
+
+if (!data.value.ftvaLARebellionIndividual) {
+  throw createError({
+    statusCode: 404,
+    statusMessage: 'Page Not Found',
+    fatal: true
+  })
+}
+
+// This is creating an index of the main content (not related content)
+// if (data.value.ftvaEvent && import.meta.prerender) {
+//   try {
+//     // Call the composable to use the indexing function
+//     const { indexContent } = useContentIndexer()
+//     // Index the event data using the composable during static build
+//     await indexContent(data.value.ftvaEvent, route.params.slug)
+//     // console.log('Event indexed successfully during static build')
+//   } catch (error) {
+//     console.error('FAILED TO INDEX EVENT during static build:', error)
+//   }
+// }
+
+const page = ref(_get(data.value, 'ftvaLARebellionIndividual', {}))
+// const series = ref(_get(data.value, 'ftvaEventSeries', {}))
+
+watch(data, (newVal, oldVal) => {
+  // console.log('In watch preview enabled, newVal, oldVal', newVal, oldVal)
+  page.value = _get(newVal, 'ftvaLARebellionIndividual', {})
+  // series.value = _get(newVal, 'ftvaEventSeries', {})
+})
+
+// Get data for Image or Carousel at top of page
+const parsedImage = computed(() => {
+  return page.value.imageCarousel
+})
+
+// Transform data for Carousel
+const parsedCarouselData = computed(() => {
+  // map image to item, map creditText to credit
+  return parsedImage.value.map((rawItem, index) => {
+    return {
+      item: [{ ...rawItem.image[0], kind: 'image' }], // Carousels on this page are always images, no videos
+      credit: rawItem?.creditText,
+    }
+  })
+})
+
+useHead({
+  title: page.value ? page.value.title : '... loading',
+  meta: [
+    {
+      hid: 'description',
+      name: 'description',
+      content: removeTags(page.value.text)
+    }
+  ]
+})
+</script>
+
+<template>
+  <main
+    id="main"
+    class="page page-detail page-event-detail"
+  >
+    <div class="one-column">
+      <NavBreadcrumb
+        class="breadcrumb"
+        data-test="breadcrumb"
+        :title="page?.title"
+      />
+
+      <ResponsiveImage
+        v-if="parsedImage && parsedImage.length === 1 && parsedImage[0]?.image && parsedImage[0]?.image?.length === 1"
+        data-test="single-image"
+        :media="parsedImage[0]?.image[0]"
+        :aspect-ratio="43.103"
+      >
+        <template
+          v-if="parsedImage[0]?.creditText"
+          #credit
+        >
+          {{ parsedImage[0]?.creditText }}
+        </template>
+      </ResponsiveImage>
+      <div
+        v-else
+        class="lightbox-container"
+      >
+        <FlexibleMediaGalleryNewLightbox
+          data-test="image-carousel"
+          :items="parsedCarouselData"
+          inline="true"
+        >
+          <template #default="slotProps">
+            <BlockTag
+              data-test="credit-text"
+              :label="parsedCarouselData[slotProps.selectionIndex]?.creditText"
+            />
+          </template>
+        </FlexibleMediaGalleryNewLightbox>
+      </div>
+    </div>
+
+    <TwoColLayoutWStickySideBar
+      data-test="second-column"
+      class="two-column"
+    >
+      <template #primaryTop>
+        <!-- <CardMeta
+          data-test="text-block"
+          :title="page?.title"
+        >
+          <template #linkedcategoryslot>
+            <NuxtLink :to="`/${series[0]?.to}`">
+              {{ series[0]?.title }}
+            </NuxtLink>
+          </template>
+  </CardMeta> -->
+      </template>
+
+      <template #sidebarTop>
+        <!-- <BlockEventDetail
+          data-test="event-details"
+          :start-date="page?.startDateWithTime"
+          :time="page?.startDateWithTime"
+          :locations="page?.location"
+        />
+        <ButtonDropdown
+          data-test="calendar-dropdown"
+          :title="parsedCalendarData?.title"
+          :event-description="parsedCalendarData?.eventDescription"
+          :start-date-with-time="parsedCalendarData?.startDateWithTime"
+          :location="parsedCalendarData?.location"
+          :is-event="true"
+          :debug-mode-enabled="false"
+        /> -->
+      </template>
+
+      <template #primaryMid>
+        <!-- <CardMeta
+          :guest-speaker="page?.guestSpeaker"
+          :tag-labels="parsedTagLabels"
+          :introduction="page?.introduction"
+        />
+        <RichText
+          v-if="page?.eventDescription"
+          data-test="event-description"
+          class="eventDescription"
+          :rich-text-content="page?.eventDescription"
+        />
+        <RichText
+          v-if="page?.acknowledements"
+          data-test="acknowledgements"
+          class="acknowledgements"
+          :rich-text-content="page?.acknowledements"
+        /> -->
+      </template>
+
+      <template #sidebarBottom>
+        <!-- <BlockInfo
+          v-if="page?.ftvaTicketInformation && page?.ftvaTicketInformation.length > 0"
+          data-test="ticket-info"
+          :ftva-ticket-information="page?.ftvaTicketInformation"
+        /> -->
+      </template>
+
+      <template #primaryBottom>
+        <!-- <DividerWayFinder />
+        <SectionScreeningDetails
+          v-if="parsedFTVAEventScreeningDetails"
+          data-test="screening-details"
+          :items="parsedFTVAEventScreeningDetails"
+        /> -->
+      </template>
+    </TwoColLayoutWStickySideBar>
+
+    <!-- <SectionWrapper
+      v-if="parsedFtvaEventSeries && parsedFtvaEventSeries.length > 0"
+      section-title="Upcoming events in this series"
+      theme="paleblue"
+      class="series-section-wrapper"
+    >
+      <SectionTeaserCard
+        v-if="parsedFtvaEventSeries && parsedFtvaEventSeries.length > 0"
+        data-test="event-series"
+        :items="parsedFtvaEventSeries"
+      />
+    </SectionWrapper> -->
+  </main>
+</template>
+
+<style lang="scss" scoped>
+// PAGE STYLES
+// .page-event-detail {
+//   position: relative;
+
+//   .two-column {
+
+//     .ftva.button-dropdown {
+//       margin-top: 30px;
+//     }
+
+//     .ftva.block-info {
+//       margin-top: 48px;
+//     }
+
+//     // SECTION SCREENING DETAILS
+//     // TODO when component is patched, remove styles?
+//     :deep(figure.responsive-video:not(:has(.video-embed))) {
+//       display: none;
+//     }
+//   }
+
+//   /* makes all EventSeries same height */
+//   :deep(.card) {
+//     min-height: 350px;
+//   }
+
+//   @media (max-width: 1200px) {
+//     :deep(.primary-column) {
+//       width: 65%;
+//     }
+//   }
+
+//   @media (max-width: 899px) {
+//     :deep(.primary-column) {
+//       width: inherit;
+//     }
+
+//     :deep(.block-tags) {
+//       padding-top: 30px;
+//     }
+//   }
+// }
+
+@import 'assets/styles/slug-pages.scss';
+</style>

--- a/pages/collections/la-rebellion/filmmakers/[slug].vue
+++ b/pages/collections/la-rebellion/filmmakers/[slug].vue
@@ -6,12 +6,12 @@ import { BlockTag, ButtonDropdown, CardMeta, DividerWayFinder, FlexibleMediaGall
 
 // HELPERS
 import _get from 'lodash/get'
+import removeTags from '../utils/removeTags'
 
 // GQL
 import FTVALARebellionFilmmakersDetail from '~/gql/queries/FTVALARebellionFilmmakersDetail.gql'
 
 // COMPOSABLE
-import removeTags from '../utils/removeTags'
 import { useContentIndexer } from '~/composables/useContentIndexer'
 
 const { $graphql } = useNuxtApp()

--- a/pages/collections/la-rebellion/filmmakers/[slug].vue
+++ b/pages/collections/la-rebellion/filmmakers/[slug].vue
@@ -2,20 +2,17 @@
 // COMPONENT RE-IMPORTS
 // TODO: remove when we have implemented component library as a module
 // https://nuxt.com/docs/guide/directory-structure/components#library-authors
-import { BlockEventDetail, BlockInfo, BlockTag, ButtonDropdown, CardMeta, DividerWayFinder, FlexibleMediaGalleryNewLightbox, NavBreadcrumb, ResponsiveImage, RichText, SectionScreeningDetails, SectionTeaserCard, SectionWrapper, TwoColLayoutWStickySideBar } from 'ucla-library-website-components'
+import { BlockTag, ButtonDropdown, CardMeta, DividerWayFinder, FlexibleMediaGalleryNewLightbox, NavBreadcrumb, ResponsiveImage, RichText, SectionScreeningDetails, SectionTeaserCard, SectionStaffSubjectLibrarian, SectionWrapper, TwoColLayoutWStickySideBar } from 'ucla-library-website-components'
 
 // HELPERS
 import _get from 'lodash/get'
 
 // GQL
-// import FTVAEventDetail from '../gql/queries/FTVAEventDetail.gql'
+import FTVALARebellionFilmmakersDetail from '~/gql/queries/FTVALARebellionFilmmakersDetail.gql'
 
 // COMPOSABLE
 import removeTags from '../utils/removeTags'
-// import { useContentIndexer } from '~/composables/useContentIndexer'
-
-// UTILS
-// import { getEventFilterLabels } from '~/utils/getEventFilterLabels'
+import { useContentIndexer } from '~/composables/useContentIndexer'
 
 const { $graphql } = useNuxtApp()
 
@@ -23,7 +20,7 @@ const route = useRoute()
 
 // DATA
 const { data, error } = await useAsyncData(`events-detail-${route.params.slug}`, async () => {
-  const data = await $graphql.default.request(ftvaLARebellionIndividual, { slug: route.params.slug })
+  const data = await $graphql.default.request(FTVALARebellionFilmmakersDetail, { slug: route.params.slug })
   return data
 })
 
@@ -41,20 +38,21 @@ if (!data.value.ftvaLARebellionIndividual) {
   })
 }
 
-// This is creating an index of the main content (not related content)
-// if (data.value.ftvaEvent && import.meta.prerender) {
-//   try {
-//     // Call the composable to use the indexing function
-//     const { indexContent } = useContentIndexer()
-//     // Index the event data using the composable during static build
-//     await indexContent(data.value.ftvaEvent, route.params.slug)
-//     // console.log('Event indexed successfully during static build')
-//   } catch (error) {
-//     console.error('FAILED TO INDEX EVENT during static build:', error)
-//   }
-// }
+// This is creating an index of the content for ES search
+if (data.value.ftvaEvent && import.meta.prerender) {
+  try {
+    // Call the composable to use the indexing function
+    const { indexContent } = useContentIndexer()
+    // Index the event data using the composable during static build
+    await indexContent(data.value.ftvaLARebellionIndividual, route.params.slug)
+    // console.log('Event indexed successfully during static build')
+  } catch (error) {
+    console.error('FAILED TO INDEX EVENT during static build:', error)
+  }
+}
 
 const page = ref(_get(data.value, 'ftvaLARebellionIndividual', {}))
+// TODO refactor for filmography data ? Delete if not needed
 // const series = ref(_get(data.value, 'ftvaEventSeries', {}))
 
 watch(data, (newVal, oldVal) => {
@@ -143,88 +141,25 @@ useHead({
         <!-- <CardMeta
           data-test="text-block"
           :title="page?.title"
-        >
-          <template #linkedcategoryslot>
-            <NuxtLink :to="`/${series[0]?.to}`">
-              {{ series[0]?.title }}
-            </NuxtLink>
-          </template>
-  </CardMeta> -->
-      </template>
-
-      <template #sidebarTop>
-        <!-- <BlockEventDetail
-          data-test="event-details"
-          :start-date="page?.startDateWithTime"
-          :time="page?.startDateWithTime"
-          :locations="page?.location"
-        />
-        <ButtonDropdown
-          data-test="calendar-dropdown"
-          :title="parsedCalendarData?.title"
-          :event-description="parsedCalendarData?.eventDescription"
-          :start-date-with-time="parsedCalendarData?.startDateWithTime"
-          :location="parsedCalendarData?.location"
-          :is-event="true"
-          :debug-mode-enabled="false"
-        /> -->
-      </template>
-
-      <template #primaryMid>
-        <!-- <CardMeta
-          :guest-speaker="page?.guestSpeaker"
-          :tag-labels="parsedTagLabels"
-          :introduction="page?.introduction"
-        />
-        <RichText
-          v-if="page?.eventDescription"
-          data-test="event-description"
-          class="eventDescription"
-          :rich-text-content="page?.eventDescription"
-        />
-        <RichText
-          v-if="page?.acknowledements"
-          data-test="acknowledgements"
-          class="acknowledgements"
-          :rich-text-content="page?.acknowledements"
-        /> -->
-      </template>
-
-      <template #sidebarBottom>
-        <!-- <BlockInfo
-          v-if="page?.ftvaTicketInformation && page?.ftvaTicketInformation.length > 0"
-          data-test="ticket-info"
-          :ftva-ticket-information="page?.ftvaTicketInformation"
-        /> -->
-      </template>
-
-      <template #primaryBottom>
-        <!-- <DividerWayFinder />
-        <SectionScreeningDetails
-          v-if="parsedFTVAEventScreeningDetails"
-          data-test="screening-details"
-          :items="parsedFTVAEventScreeningDetails"
-        /> -->
+        > -->
+        {{ page }}
       </template>
     </TwoColLayoutWStickySideBar>
 
-    <!-- <SectionWrapper
-      v-if="parsedFtvaEventSeries && parsedFtvaEventSeries.length > 0"
-      section-title="Upcoming events in this series"
+    <!-- TODO: add conditional render once vars exist
+     v-if="parsedFilmography && parsedFilmography.length > 0" -->
+    <SectionWrapper
+      section-title="Filmography"
       theme="paleblue"
       class="series-section-wrapper"
     >
-      <SectionTeaserCard
-        v-if="parsedFtvaEventSeries && parsedFtvaEventSeries.length > 0"
-        data-test="event-series"
-        :items="parsedFtvaEventSeries"
-      />
-    </SectionWrapper> -->
+      <!-- <SectionStaffSubjectLibrarian /> -->
+    </SectionWrapper>
   </main>
 </template>
 
 <style lang="scss" scoped>
-// PAGE STYLES
+// PAGE STYLES - USE OLD STYLES
 // .page-event-detail {
 //   position: relative;
 


### PR DESCRIPTION
Connected to [APPS-3092](https://jira.library.ucla.edu/browse/APPS-3092)

**Page/Pages Created/updated:** /collections/la-rebellion/filmmakers/[slug].vue from #{APPS-3092}

**Notes:**

Created & Tested GQL query on 'test-person' in test-craft, worked fine.
Query does not yet work in production but plans to migrate before the page is due.

**Time Report:**

This took me 8ish hours to build this.

I spent 4ish hours Tuesday researching & attempting to get relatedEntries in craft without success, however Axa was able to reformat the data so that this became unnecessary. I would still like to understand that later. 

**Checklist:**

-   [X] I added github label for semantic versioning
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   [X] I added notes above about how long it took to build this component
-   ~~[ ] UX has reviewed this PR~~
-   [ ] I assigned this PR to someone to review


[APPS-3092]: https://uclalibrary.atlassian.net/browse/APPS-3092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ