### PR TITLE
chore: APPS-3162 Replace SectionStaffSubjectLibrarian component with new TableComponent

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "nuxt-graphql-request": "^7.0.5",
     "sass": "^1.66.1",
     "ucla-library-design-tokens": "^5.28.0",
-    "ucla-library-website-components": "3.46.1"
+    "ucla-library-website-components": "3.47.0"
   },
   "engines": {
     "pnpm": "^9.12.1"

--- a/pages/collections/la-rebellion/filmmakers/[slug].vue
+++ b/pages/collections/la-rebellion/filmmakers/[slug].vue
@@ -2,7 +2,7 @@
 // COMPONENT RE-IMPORTS
 // TODO: remove when we have implemented component library as a module
 // https://nuxt.com/docs/guide/directory-structure/components#library-authors
-import { BlockTag, ButtonDropdown, CardMeta, FlexibleMediaGalleryNewLightbox, NavBreadcrumb, ResponsiveImage, RichText, SectionStaffSubjectLibrarian, SectionWrapper, TwoColLayoutWStickySideBar } from 'ucla-library-website-components'
+import { BlockTag, ButtonDropdown, CardMeta, FlexibleMediaGalleryNewLightbox, NavBreadcrumb, ResponsiveImage, RichText, SectionWrapper, SmartLink, TableComponent, TableRow, TwoColLayoutWStickySideBar } from 'ucla-library-website-components'
 
 // HELPERS
 import _get from 'lodash/get'
@@ -187,10 +187,43 @@ useHead({
       theme="paleblue"
       class="filmography-section-wrapper"
     >
-      <section-staff-subject-librarian
-        :items="page.associatedFilms"
+      <TableComponent
         :table-headers="['', 'Film', 'Role', 'Year']"
-      />
+        :table-caption="'Filmography'"
+      >
+        <TableRow
+          v-for="item, index in parsedAssociatedFilms"
+          :key="index"
+          :num-cells="4"
+        >
+          <template #column1>
+            <div class="responsive-image">
+              <ResponsiveImage :media="item.image[0]" />
+            </div>
+          </template>
+          <template #column2>
+            <h1>
+              <SmartLink
+                class="film-title"
+                :to="item.filmLink[0].uri"
+              >
+                {{ item.titleGeneral }}
+              </SmartLink>
+            </h1>
+            <RichText :rich-text-content="item.description" />
+          </template>
+          <template #column3>
+            <p class="subtitle">
+              {{ item.roles }}
+            </p>
+          </template>
+          <template #column4>
+            <p class="subtitle">
+              {{ item.year }}
+            </p>
+          </template>
+        </TableRow>
+      </TableComponent>
     </SectionWrapper>
   </main>
 </template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: ^5.28.0
         version: 5.28.0
       ucla-library-website-components:
-        specifier: 3.46.1
-        version: 3.46.1(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
+        specifier: 3.47.0
+        version: 3.47.0(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
 
 packages:
 
@@ -4459,8 +4459,8 @@ packages:
   ucla-library-design-tokens@5.28.0:
     resolution: {integrity: sha512-qgxGlK3/m0VwYGumzLZTTB/ae03DY41+80vFhm4+gukzh8XiqUsN71cg3ijk23Dl9awyicoELbRgnUV4nj3e0g==}
 
-  ucla-library-website-components@3.46.1:
-    resolution: {integrity: sha512-5UHbUT5a/1IeJWIxT81GtLUL064SWfy7mGy1jZi3eiIJFLNmfmBBE8bzPwTTPjY8G0e+4999Uh1ceDVVGO2HbQ==}
+  ucla-library-website-components@3.47.0:
+    resolution: {integrity: sha512-PWNGKpvcgVs0qT+euo5KINiKBI5XFqEeu6lubj8a3FOi9ywneCCl1B93eTkOtgjzHZrhiTGuQBoEX9x2YkEV7w==}
     engines: {pnpm: ^9.12.1}
     peerDependencies:
       vue: ^3.5.12
@@ -10001,7 +10001,7 @@ snapshots:
 
   ucla-library-design-tokens@5.28.0: {}
 
-  ucla-library-website-components@3.46.1(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))):
+  ucla-library-website-components@3.47.0(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))):
     dependencies:
       '@vuepic/vue-datepicker': 8.8.1(vue@3.5.12(typescript@5.6.3))
       '@vueuse/components': 11.3.0(vue@3.5.12(typescript@5.6.3))


### PR DESCRIPTION
Connected to [APPS-3162](https://jira.library.ucla.edu/browse/APPS-3162)

**Page/Pages Created/updated:** /collections/la-rebellion/filmmakers/[slug].vue from #APPS-3162

**Notes:**

Replaced the old StaffSubjectLibrarian specific component with the new table component
https://deploy-preview-111--test-ftva.netlify.app/collections/la-rebellion/filmmakers/test-person?preview=true


Sidenote: I noticed the column headers on the table were askew ([even before refactor](https://deploy-preview-110--test-ftva.netlify.app/collections/la-rebellion/filmmakers/test-person)), so I will create a ticket to fix those at the component level. The test data in storybook didn't reveal this issue since the column data I used was too uniform! 

**Time Report:**

This took me 2ish hours to build this.

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   [X] I added notes above about how long it took to build this component
-   ~~[] UX has reviewed this PR~~
-   [ ] I assigned this PR to someone to review


[APPS-3162]: https://uclalibrary.atlassian.net/browse/APPS-3162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ