### PR TITLE
fix: update allFtvaFpb query to get rid of the associatedCards Flexible Block

### DIFF
--- a/gql/fragments/collections/AllFtvaFpb.gql
+++ b/gql/fragments/collections/AllFtvaFpb.gql
@@ -1,4 +1,3 @@
-#import "../gql/fragments/BlockAssociatedTopicCardsFragment.gql"
 #import "../gql/fragments/BlockCallToActionFragment.gql"
 #import "../gql/fragments/BlockFormFragment.gql"
 #import "../gql/fragments/BlockHorizontalDividerFragment.gql"
@@ -15,9 +14,7 @@ fragment AllFtvaFpb on ElementInterface {
         id
         typeHandle
 
-        ... on allFtvaFpb_associatedTopics_BlockType {
-           ...BlockAssociatedTopicCardsFragment
-        }
+
         ... on allFtvaFpb_callToAction_BlockType {
             ...BlockCallToActionFragment
         }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -217,4 +217,7 @@ export default defineNuxtConfig({
     payloadExtraction: true,
     sharedPrerenderData: true
   } */
+ experimental: {
+    sharedPrerenderData: true,
+  },
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -217,7 +217,7 @@ export default defineNuxtConfig({
     payloadExtraction: true,
     sharedPrerenderData: true
   } */
- experimental: {
+  experimental: {
     sharedPrerenderData: true,
   },
 })


### PR DESCRIPTION
Updates the AllFtvaFpb query to get rid of the associatedCards Flexible Block that we are replacing with CardWithImage.

We are ONLY removing the associatedCards Flexible Block in this PR so that the Craft PR: [fix: Replace Associated Topics Card flexible block with Flexible Card](https://github.com/UCLALibrary/craftcms/pull/306/files) will not break.

The CardWithImage Flexible Block will be added in a separate PR.