### PR TITLE
feat: APPS-3231 Refactor BlockInfo on slug pages

### DIFF
--- a/assets/styles/slug-pages.scss
+++ b/assets/styles/slug-pages.scss
@@ -40,3 +40,39 @@
     }
   }
 }
+
+.block-info.ticket-info {
+  padding: 20px;
+
+  .block-info-header {
+    @include ftva-subtitle-1;
+    text-align: center;
+    color: $heading-grey;
+    border-bottom: 1px solid $grey-blue;
+    padding: 8px 0;
+  }
+
+  .block-info-list {
+    padding: 16px 0 16px 20px;
+
+    li {
+      @include ftva-body-2;
+      color: $body-grey;
+
+      &::marker {
+        color: $body-grey;
+      }
+    }
+  }
+
+  :deep(.block-info-end-wrapper) {
+    margin: 0 auto;
+  }
+
+  .button-link {
+    font-size: 18px;
+    padding-left: 16px;
+    padding-right: 16px;
+    margin: 10px auto;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "nuxt-graphql-request": "^7.0.5",
     "sass": "^1.66.1",
     "ucla-library-design-tokens": "^5.29.0",
-    "ucla-library-website-components": "3.51.0"
+    "ucla-library-website-components": "3.56.0"
   },
   "engines": {
     "pnpm": "^9.12.1"

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -251,9 +251,36 @@ useHead({
       <template #sidebarBottom>
         <BlockInfo
           v-if="page?.ftvaTicketInformation && page?.ftvaTicketInformation.length > 0"
+          color-scheme="paleblue"
           data-test="ticket-info"
-          :ftva-ticket-information="page?.ftvaTicketInformation"
-        />
+        >
+          <template #block-info-top>
+            <h3 class="block-info-header">
+              Ticket Info
+            </h3>
+          </template>
+
+          <template #block-info-mid>
+            <ul class="block-info-list">
+              <li
+                v-for="(item, index) in page?.ftvaTicketInformation"
+                :key="`${item}-${index}`"
+              >
+                {{ item.title }}
+              </li>
+            </ul>
+          </template>
+
+          <template #block-info-end>
+            <ButtonLink
+              label="Plan Your Visit"
+              to="/plan-your-visit"
+              class="button"
+              :is-secondary="true"
+              icon-name="none"
+            />
+          </template>
+        </BlockInfo>
       </template>
 
       <template #primaryBottom>
@@ -293,7 +320,45 @@ useHead({
     }
 
     .ftva.block-info {
+      // margin-top: 48px;
+    }
+
+    // Refactor to shared filed
+    .block-info {
       margin-top: 48px;
+      padding: 20px;
+
+      :deep(.block-info-end-wrapper) {
+        margin: 0 auto;
+      }
+
+      :deep(.block-info-header) {
+        @include ftva-subtitle-1;
+        text-align: center;
+        color: $heading-grey;
+        border-bottom: 1px solid $grey-blue;
+        padding: 8px 0;
+      }
+
+      :deep(.block-info-list) {
+        padding: 16px 0 16px 20px;
+
+        li {
+          @include ftva-body-2;
+          color: $body-grey;
+
+          &::marker {
+            color: $body-grey;
+          }
+        }
+      }
+
+      :deep(.button-link) {
+        font-size: 18px;
+        padding-left: 16px;
+        padding-right: 16px;
+        margin: 10px auto;
+      }
     }
 
     // SECTION SCREENING DETAILS

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -253,13 +253,13 @@ useHead({
           v-if="page?.ftvaTicketInformation && page?.ftvaTicketInformation.length > 0"
           color-scheme="paleblue"
           data-test="ticket-info"
+          class="ticket-info"
         >
           <template #block-info-top>
             <h3 class="block-info-header">
               Ticket Info
             </h3>
           </template>
-
           <template #block-info-mid>
             <ul class="block-info-list">
               <li
@@ -270,7 +270,6 @@ useHead({
               </li>
             </ul>
           </template>
-
           <template #block-info-end>
             <ButtonLink
               label="Plan Your Visit"
@@ -309,56 +308,17 @@ useHead({
 </template>
 
 <style lang="scss" scoped>
-// PAGE STYLES
 .page-event-detail {
   position: relative;
 
   .two-column {
 
-    .ftva.button-dropdown {
+    .button-dropdown {
       margin-top: 30px;
     }
 
-    .ftva.block-info {
-      // margin-top: 48px;
-    }
-
-    // Refactor to shared filed
     .block-info {
       margin-top: 48px;
-      padding: 20px;
-
-      :deep(.block-info-end-wrapper) {
-        margin: 0 auto;
-      }
-
-      :deep(.block-info-header) {
-        @include ftva-subtitle-1;
-        text-align: center;
-        color: $heading-grey;
-        border-bottom: 1px solid $grey-blue;
-        padding: 8px 0;
-      }
-
-      :deep(.block-info-list) {
-        padding: 16px 0 16px 20px;
-
-        li {
-          @include ftva-body-2;
-          color: $body-grey;
-
-          &::marker {
-            color: $body-grey;
-          }
-        }
-      }
-
-      :deep(.button-link) {
-        font-size: 18px;
-        padding-left: 16px;
-        padding-right: 16px;
-        margin: 10px auto;
-      }
     }
 
     // SECTION SCREENING DETAILS

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -257,13 +257,13 @@ useHead({
           v-if="page?.ftvaTicketInformation && page?.ftvaTicketInformation.length > 0"
           color-scheme="paleblue"
           data-test="ticket-info"
+          class="ticket-info"
         >
           <template #block-info-top>
             <h3 class="block-info-header">
               Ticket Info
             </h3>
           </template>
-
           <template #block-info-mid>
             <ul class="block-info-list">
               <li
@@ -274,7 +274,6 @@ useHead({
               </li>
             </ul>
           </template>
-
           <template #block-info-end>
             <ButtonLink
               label="Plan Your Visit"
@@ -367,43 +366,6 @@ useHead({
 
     .section-wrapper.theme-paleblue {
       background-color: var(--pale-blue);
-    }
-  }
-
-  // Refactor to shared filed
-  .block-info {
-    padding: 20px;
-
-    :deep(.block-info-end-wrapper) {
-      margin: 0 auto;
-    }
-
-    :deep(.block-info-header) {
-      @include ftva-subtitle-1;
-      text-align: center;
-      color: $heading-grey;
-      border-bottom: 1px solid $grey-blue;
-      padding: 8px 0;
-    }
-
-    :deep(.block-info-list) {
-      padding: 16px 0 16px 20px;
-
-      li {
-        @include ftva-body-2;
-        color: $body-grey;
-
-        &::marker {
-          color: $body-grey;
-        }
-      }
-    }
-
-    :deep(.button-link) {
-      font-size: 18px;
-      padding-left: 16px;
-      padding-right: 16px;
-      margin: 10px auto;
     }
   }
 

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -255,9 +255,36 @@ useHead({
       <template #sidebarBottom>
         <BlockInfo
           v-if="page?.ftvaTicketInformation && page?.ftvaTicketInformation.length > 0"
+          color-scheme="paleblue"
           data-test="ticket-info"
-          :ftva-ticket-information="page?.ftvaTicketInformation"
-        />
+        >
+          <template #block-info-top>
+            <h3 class="block-info-header">
+              Ticket Info
+            </h3>
+          </template>
+
+          <template #block-info-mid>
+            <ul class="block-info-list">
+              <li
+                v-for="(item, index) in page?.ftvaTicketInformation"
+                :key="`${item}-${index}`"
+              >
+                {{ item.title }}
+              </li>
+            </ul>
+          </template>
+
+          <template #block-info-end>
+            <ButtonLink
+              label="Plan Your Visit"
+              to="/plan-your-visit"
+              class="button"
+              :is-secondary="true"
+              icon-name="none"
+            />
+          </template>
+        </BlockInfo>
       </template>
     </TwoColLayoutWStickySideBar>
 
@@ -340,6 +367,43 @@ useHead({
 
     .section-wrapper.theme-paleblue {
       background-color: var(--pale-blue);
+    }
+  }
+
+  // Refactor to shared filed
+  .block-info {
+    padding: 20px;
+
+    :deep(.block-info-end-wrapper) {
+      margin: 0 auto;
+    }
+
+    :deep(.block-info-header) {
+      @include ftva-subtitle-1;
+      text-align: center;
+      color: $heading-grey;
+      border-bottom: 1px solid $grey-blue;
+      padding: 8px 0;
+    }
+
+    :deep(.block-info-list) {
+      padding: 16px 0 16px 20px;
+
+      li {
+        @include ftva-body-2;
+        color: $body-grey;
+
+        &::marker {
+          color: $body-grey;
+        }
+      }
+    }
+
+    :deep(.button-link) {
+      font-size: 18px;
+      padding-left: 16px;
+      padding-right: 16px;
+      margin: 10px auto;
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: ^5.29.0
         version: 5.29.0
       ucla-library-website-components:
-        specifier: 3.51.0
-        version: 3.51.0(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
+        specifier: 3.56.0
+        version: 3.56.0(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
 
 packages:
 
@@ -4459,8 +4459,8 @@ packages:
   ucla-library-design-tokens@5.29.0:
     resolution: {integrity: sha512-jKHo5fQU7rz1nxzi8in5MyTF05mI5Rctmp49xQyXzNNHxsQx0l23MueKbvWbD23ePa8P+rHjhlqf9Vg0LgfGrQ==}
 
-  ucla-library-website-components@3.51.0:
-    resolution: {integrity: sha512-XPl0/tSUDtU3Pl8QqSEb7E99qOQg1GWlr7MIzmLb/Iv4S/VlpCO1ZUeJyvTBA7aER9egCCGQfCxTNw9cwFccLQ==}
+  ucla-library-website-components@3.56.0:
+    resolution: {integrity: sha512-lXYmFKbXoCbOy+9kxXY0GXs/ZT9kGQ5nmiJ2PGL26NuA0srHhFi4Dxl0qreAKjWiz4f+kS2oaAVFNVQMZ1nYkw==}
     engines: {pnpm: ^9.12.1}
     peerDependencies:
       vue: ^3.5.12
@@ -10001,7 +10001,7 @@ snapshots:
 
   ucla-library-design-tokens@5.29.0: {}
 
-  ucla-library-website-components@3.51.0(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))):
+  ucla-library-website-components@3.56.0(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))):
     dependencies:
       '@vuepic/vue-datepicker': 8.8.1(vue@3.5.12(typescript@5.6.3))
       '@vueuse/components': 11.3.0(vue@3.5.12(typescript@5.6.3))


### PR DESCRIPTION
Connected to [APPS-3231](https://jira.library.ucla.edu/browse/APPS-3231)

**Pages Updated:** 
- /pages/events/[slug].vue
- /pages/series/[slug].vue

**Notes:**
- Updated component library to `3.56.0`
- Refactored `BlockInfo` component on Event and Series slug pages
- Refactored component CSS to shared slug stylesheet.

**Previews:**
- Event slug:
  - Before refactor: https://deploy-preview-113--test-ftva.netlify.app/events/step-up-2-07-07-25/
  - After: https://deploy-preview-116--test-ftva.netlify.app/events/step-up-2-07-07-25/

- Series slug:
  - Before refactor: https://deploy-preview-113--test-ftva.netlify.app/series/step-into-possibilities/
  - After: https://deploy-preview-116--test-ftva.netlify.app/series/step-into-possibilities/

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I double checked it looks like the designs
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~
-   [x] I have requested a PR review from the Dev team

[APPS-3231]: https://uclalibrary.atlassian.net/browse/APPS-3231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ