### PR TITLE
fix: APPS-3248 Add spacing between Flexible Blocks

### DIFF
--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -115,40 +115,38 @@ onMounted(() => {
           </template>
         </FlexibleMediaGalleryNewLightbox>
       </div>
+
+      <PageAnchor
+        v-if="h2Array.length >= 3"
+        :section-titles="h2Array"
+      />
+
+      <TwoColLayoutWStickySideBar
+        data-test="second-column"
+        class="two-column"
+      >
+        <template #primaryTop>
+          <div v-if="page.formattedTitle">
+            <h3 class="page-title">
+              <rich-text :rich-text-content="page.formattedTitle" />
+            </h3>
+          </div>
+
+          <div v-else>
+            <h3 class="page-title">
+              {{ page.title }}
+            </h3>
+          </div>
+        </template>
+
+        <template #primaryMid>
+          <FlexibleBlocks
+            class="flexible-content"
+            :blocks="page.blocks"
+          />
+        </template>
+      </TwoColLayoutWStickySideBar>
     </div>
-
-    <TwoColLayoutWStickySideBar
-      data-test="second-column"
-      class="two-column"
-    >
-      <template #primaryTop>
-        <div v-if="page.formattedTitle">
-          <h3 class="page-title">
-            <rich-text :rich-text-content="page.formattedTitle" />
-          </h3>
-        </div>
-
-        <div v-else>
-          <h3 class="page-title">
-            {{ page.title }}
-          </h3>
-        </div>
-      </template>
-
-      <template #primaryMid>
-        <FlexibleBlocks
-          class="flexible-content"
-          :blocks="page.blocks"
-        />
-      </template>
-
-      <template #sidebarTop>
-        <PageAnchor
-          v-if="h2Array.length >= 3"
-          :section-titles="h2Array"
-        />
-      </template>
-    </TwoColLayoutWStickySideBar>
   </main>
 </template>
 
@@ -164,7 +162,20 @@ onMounted(() => {
 
     @include ftva-h2;
     color: $heading-grey;
-    margin: 0 0 24px;
+    margin: 0;
+  }
+
+  .two-column {
+    display: block;
+    margin-top: 32px;
+
+    .sidebar-column {
+      display:none;
+    }
+
+    :deep(.primary-section-wrapper) {
+      margin-top: 0;
+    }
   }
 
   // Apply spacing between flexible blocks
@@ -172,6 +183,44 @@ onMounted(() => {
   .flexible-blocks.flexible-content {
     :deep(.section-wrapper) {
       margin: var(--space-2xl) auto;
+    }
+
+    :deep(.section-wrapper:first-of-type){
+      margin-top: 24px;
+    }
+  }
+
+  .ftva.page-anchor {
+    margin-top: 24px;
+    float: right; // Delete after APPS-3263 is implemented
+    top: 65px; // Sticks anchor after sticky header
+  }
+
+  @media (max-width: 1200px){
+    .two-column {
+      :deep(.primary-section-wrapper) {
+        padding-left: 0;
+      }
+
+      :deep(.primary-column) {
+        width: 80%;
+      }
+    }
+  }
+
+  @media (max-width: 1024px){
+    .two-column {
+      :deep(.primary-column) {
+        width: 100%;
+      }
+    }
+  }
+
+  @media (max-width: 900px){
+    .flexible-blocks.flexible-content {
+      :deep(.section-wrapper:first-of-type){
+        margin-top: 0;
+      }
     }
   }
 }

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -179,13 +179,12 @@ onMounted(() => {
   }
 
   // Apply spacing between flexible blocks
-  // See https://github.com/UCLALibrary/ucla-library-website-components/pull/709
   .flexible-blocks.flexible-content {
     :deep(.section-wrapper) {
       margin: var(--space-2xl) auto;
     }
 
-    :deep(.section-wrapper:first-of-type){
+    :deep(.section-header + div .section-wrapper ){
       margin-top: 24px;
     }
   }
@@ -218,7 +217,7 @@ onMounted(() => {
 
   @media (max-width: 900px){
     .flexible-blocks.flexible-content {
-      :deep(.section-wrapper:first-of-type){
+      :deep(.section-header + div .section-wrapper ){
         margin-top: 0;
       }
     }

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -85,7 +85,7 @@ onMounted(() => {
 <template lang="html">
   <main
     id="main"
-    class="page page-detail page-general-content"
+    class="page page-detail page-detail--paleblue page-general-content"
   >
     <div class="one-column">
       <NavBreadcrumb data-test="breadcrumb" />

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -166,6 +166,14 @@ onMounted(() => {
     color: $heading-grey;
     margin: 0 0 24px;
   }
+
+  // Apply spacing between flexible blocks
+  // See https://github.com/UCLALibrary/ucla-library-website-components/pull/709
+  .flexible-blocks.flexible-content {
+    :deep(.section-wrapper) {
+      margin: var(--space-2xl) auto;
+    }
+  }
 }
 
 @import 'assets/styles/slug-pages.scss';


### PR DESCRIPTION
Connected to [APPS-3248](https://jira.library.ucla.edu/browse/APPS-3248)

**Page Updated:** /pages/[...slug].vue

**Notes:**

- When FlexibleBlocks is wrapped by another component that also uses the SectionWrapper component (such as TwoColLayoutWStickySidebar on the General Content template page), `top-level`--a computed CSS class from SectionWrapper--is not applied to the SectionWrapper elements/tags in the various flexible blocks. `top-level` appears to be needed for specific spacing styles to be applied to the blocks. Without it, the blocks have no spacing between them.
- Current solution is to apply the missing styles directly at the page level
  - A second option is to remove the parent component, which I've opted not to do here
 - Reorganized layout because placing the page-anchor inside TwoColLayout causes the anchor to lose stickiness on mobile
 - Updated CSS for block spacing and the adjusted layout

**Before:** https://deploy-preview-120--test-ftva.netlify.app/about/

**After:** https://deploy-preview-124--test-ftva.netlify.app/about/


**Checklist:**

-   [x] I added github label for semantic versioning
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   [x] UX has reviewed this PR
-   [x] I assigned this PR to someone to review


[APPS-3248]: https://uclalibrary.atlassian.net/browse/APPS-3248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ