### PR TITLE
fix: APPS 3265 Update Vuetify config in FTVA Nuxt

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "test": "pnpm lint && pnpm typecheck"
   },
   "dependencies": {
-    "@mdi/font": "^7.4.47",
     "@pinia/nuxt": "^0.5.5",
     "@vueuse/core": "^11.1.0",
     "nuxt": "^3.13.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@percy/cli": "^1.27.0",
     "@percy/cypress": "^3.1.2",
     "@types/node": "^18.17.3",
+    "@ucla-library/component-library-nuxt-module": "1.2.2",
     "@zadigetvoltaire/nuxt-gtm": "^0.0.13",
     "cypress": "^12.17.4",
     "date-fns": "^3.6.0",
@@ -40,8 +41,7 @@
     "lodash": "^4.17.21",
     "nuxt-graphql-request": "^7.0.5",
     "sass": "^1.66.1",
-    "ucla-library-design-tokens": "^5.30.0",
-    "@ucla-library/component-library-nuxt-module": "1.2.0"
+    "ucla-library-design-tokens": "^5.30.0"
   },
   "engines": {
     "pnpm": "^9.12.1"

--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -1,9 +1,7 @@
 // plugins/vuetify.ts
-import 'vuetify/styles' // Import Vuetify styles
 import { createVuetify } from 'vuetify'
 import { VCalendar } from 'vuetify/labs/VCalendar' // Import VCalendar
 import { VCard, VList, VListItem, VMenu, VSheet } from 'vuetify/lib/components/index.mjs'
-import '@mdi/font/css/materialdesignicons.css' // Import Material Design Icons
 
 export default defineNuxtPlugin((nuxtApp) => {
   const vuetify = createVuetify({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^18.17.3
         version: 18.19.59
       '@ucla-library/component-library-nuxt-module':
-        specifier: 1.2.0
-        version: 1.2.0(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
+        specifier: 1.2.2
+        version: 1.2.2(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
       '@zadigetvoltaire/nuxt-gtm':
         specifier: ^0.0.13
         version: 0.0.13(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.59)(eslint@8.57.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.24.0)(sass@1.80.3)(terser@5.36.0)(typescript@5.6.3)(vite@5.4.10(@types/node@18.19.59)(sass@1.80.3)(terser@5.36.0))(webpack-sources@3.2.3))(rollup@4.24.0)(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
@@ -1304,15 +1304,15 @@ packages:
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.5.0':
-    resolution: {integrity: sha512-FtPXM2LvnQozo69TxaSBuwTwf8YmvDHS3HAuGywN6975xTMXZOuOyVja2oQvYSexmTz7tJ2A9Gjr+UqZwwx2hA==}
+  '@ucla-library-monorepo/ucla-library-website-components@1.6.1':
+    resolution: {integrity: sha512-cQg3VI+105Kv/7xUTZ9UfXhMO6fEP1gTPJ4a3KfzVv0pYeZvrk0d7siz4jG3jOqMvLZ+ybztrMxIFpXU/HFVMw==}
     engines: {pnpm: ^9.12.1}
     peerDependencies:
       vue: ^3.5.12
       vuetify: ^3.7.4
 
-  '@ucla-library/component-library-nuxt-module@1.2.0':
-    resolution: {integrity: sha512-MttiYt2FDECheymKQRpbKC7+TTl1lQ5XCD8KqCnidIhPBRRB8iaI3g2LV0D8bSX/16laxE8/zzxCjy5ZO+qiFw==}
+  '@ucla-library/component-library-nuxt-module@1.2.2':
+    resolution: {integrity: sha512-A90ygppGaTzSDTKeevpQCdWbtJNbEmbdjtsqvkSKeG62lIYrjwthhg21the20/d0mOqr9m/yV6XpTfGQ5JBsog==}
     engines: {pnpm: ^9.12.1}
 
   '@ungap/structured-clone@1.2.0':
@@ -6468,7 +6468,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.5.0(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
+  '@ucla-library-monorepo/ucla-library-website-components@1.6.1(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
     dependencies:
       '@vuepic/vue-datepicker': 8.8.1(vue@3.5.12(typescript@5.6.3))
       '@vueuse/components': 11.3.0(vue@3.5.12(typescript@5.6.3))
@@ -6484,10 +6484,10 @@ snapshots:
       - '@vue/composition-api'
       - typescript
 
-  '@ucla-library/component-library-nuxt-module@1.2.0(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
+  '@ucla-library/component-library-nuxt-module@1.2.2(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
     dependencies:
       '@nuxt/kit': 3.16.0(magicast@0.3.5)
-      '@ucla-library-monorepo/ucla-library-website-components': 1.5.0(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
+      '@ucla-library-monorepo/ucla-library-website-components': 1.6.1(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - magicast

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@mdi/font':
-        specifier: ^7.4.47
-        version: 7.4.47
       '@pinia/nuxt':
         specifier: ^0.5.5
         version: 0.5.5(magicast@0.3.5)(rollup@4.24.0)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
@@ -763,9 +760,6 @@ packages:
   '@mapbox/node-pre-gyp@1.0.11':
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
     hasBin: true
-
-  '@mdi/font@7.4.47':
-    resolution: {integrity: sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==}
 
   '@netlify/functions@2.8.2':
     resolution: {integrity: sha512-DeoAQh8LuNPvBE4qsKlezjKj0PyXDryOFJfJKo3Z1qZLKzQ21sT314KQKPVjfvw6knqijj+IO+0kHXy/TJiqNA==}
@@ -5614,8 +5608,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  '@mdi/font@7.4.47': {}
 
   '@netlify/functions@2.8.2':
     dependencies:


### PR DESCRIPTION
Connected to [APPS-3265](https://jira.library.ucla.edu/browse/APPS-3265)

**Notes:**

Companion PR to [similar update of Vuetify styles/config clean up in the component library](https://github.com/UCLALibrary/ucla-library-website-components/pull/718).

This task removes all of the MaterialDesign icon styles, but minimally reduces the amount of Vuetify styles. See screenshots below. Still unclear if this will significantly decrease the overall CSS load.

Vuetify's calendar component depends on several other components, though not all of the subcomponents' styles are imported. 

- Updated Vuetify plugin
  - Removed Vuetify styles import
  - Removed Material Design icon import
- Uninstalled `mdi/font` package
- Updated Nuxt Modules to `1.2.2`
- Verified BaseCalendar instance unaffected
  - Before: https://deploy-preview-127--test-ftva.netlify.app/events?view=calendar&page=1
  - After: https://deploy-preview-131--test-ftva.netlify.app/events?view=calendar&page=1

**Screenshots:**

- Removing the MDI import stripped out all the mdi styles without affecting our Vuetify customizations: 

![mdi-before](https://github.com/user-attachments/assets/05950292-5622-4357-933a-62af32a38584)

![mdi-after](https://github.com/user-attachments/assets/5407dce4-67a6-4fb1-906e-1659f5440338)

- Minimal reduction to Vuetify styles:

![vuetify-before](https://github.com/user-attachments/assets/a2ae50f9-054b-43fc-8982-d37f1c5dbbc0)

![vuetify-after](https://github.com/user-attachments/assets/5cbd53c8-ce13-4a22-a4c7-2c00cb2da1e9)


**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I double checked it looks like the designs
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~
-   [x] I have requested a PR review from the Dev team


[APPS-3265]: https://uclalibrary.atlassian.net/browse/APPS-3265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ