### PR TITLE
feat: APPS-3290 Add CollectionsListingType GQL

### DIFF
--- a/gql/queries/FTVACollectionTypeListing.gql
+++ b/gql/queries/FTVACollectionTypeListing.gql
@@ -1,0 +1,43 @@
+#import "../gql/fragments/Image.gql"
+
+query FTVACollectionsListing($section: [String!], $collectionType: [QueryArgument]) {
+  entry(section: $section) {
+    id
+    slug
+    uri
+    sectionHandle
+    title: titleGeneral
+    summary
+    sectionHeader {
+      sectionTitle
+      sectionSummary
+    }
+    associatedGeneralContentPagesFtva {
+      id
+      title
+      slug
+      uri
+      ftvaImage {
+        ...Image
+      }
+      imageCarousel {
+        ... on imageCarousel_imageCarousel_BlockType {
+          image {
+            ...Image
+          }
+        }
+      }
+    }
+  }
+  entries(
+    section: "ftvaCollection"
+    orderBy: "title"
+    ftvaCollectionType: $collectionType
+  ) {
+    title
+    uri
+    ftvaImage {
+      ...Image
+    }
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -40,7 +40,7 @@ export default defineNuxtConfig({
       failOnError: false,
       concurrency: 50,
       interval: 1000,
-      routes: ['/', '/events/', '/collections/', '/collections/la-rebellion/filmmakers/', '/series/', '/blog/', '/archive-research-study-center/', '/billy-wilder-theater/'],
+      routes: ['/', '/events/', '/collections/', '/collections/motion-picture/', '/collections/la-rebellion/filmmakers/', '/series/', '/blog/', '/archive-research-study-center/', '/billy-wilder-theater/'],
     },
     hooks: {
       'prerender:generate'(route) {
@@ -81,6 +81,9 @@ export default defineNuxtConfig({
           }
           routes.add('/instructional-media-collections-services')
           routes.add('/archive-research-study-center')
+          routes.add('/collections/motion-picture')
+          routes.add('/collections/television')
+          routes.add('/collections/watch-listen-online')
         }
         // eslint-disable-next-line no-console
         console.log('prerender:routes ctx.routes', routes)

--- a/pages/collections/motion-picture/index.vue
+++ b/pages/collections/motion-picture/index.vue
@@ -1,0 +1,94 @@
+<script setup>
+
+// HELPERS
+import _get from 'lodash/get'
+
+// GQL
+import FTVACollectionTypeListing from '../gql/queries/FTVACollectionTypeListing.gql'
+
+const { $graphql } = useNuxtApp()
+
+const route = useRoute()
+
+// routes this page supports:
+const routeNameToSectionMap = {
+  '/collections/motion-picture': {
+    sectionName: 'ftvaListingMotionPictureCollections',
+    collection: 'motionPicture'
+  },
+  '/collections/television': {
+    sectionName: 'ftvaListingTelevisionCollections',
+    collection: 'television'
+  },
+  '/collections/watch-listen-online': {
+    sectionName: 'ftvaListingWatchAndListenOnline',
+    collection: 'watch-listen-online'
+  }
+}
+
+const { data, error } = await useAsyncData(route.path, async () => {
+  // lookup section based on routeNameToSectionMap
+  const data = await $graphql.default.request(FTVACollectionTypeListing, { section: routeNameToSectionMap[route.path].sectionName, collectionType: routeNameToSectionMap[route.path].collection })
+  return data
+})
+
+if (error.value) {
+  throw createError({
+    ...error.value, statusMessage: 'Page not found.' + error.value, fatal: true
+  })
+}
+
+if (!data.value.entry) {
+  throw createError({
+    statusCode: 404,
+    statusMessage: 'Page Not Found',
+    fatal: true
+  })
+}
+
+// DATA
+const page = ref(_get(data.value, 'entry', {}))
+const collection = ref(_get(data.value, 'entries', {}))
+
+console.log('page data: ', page.value)
+console.log('collection data: ', collection.value)
+
+// PREVIEW WATCHER FOR CRAFT CONTENT
+watch(data, (newVal, oldVal) => {
+  page.value = _get(newVal, 'entry', {})
+  collection.value = _get(newVal, 'entries', [])
+})
+
+definePageMeta({
+  layout: 'default',
+  path: '/collections/motion-picture',
+  alias: ['/collections/television', '/collections/watch-listen-online']
+})
+
+useHead({
+  title: page.value ? page.value.title : '... loading',
+  meta: [
+    {
+      hid: 'description',
+      name: 'description',
+      content: removeTags(page.value.summary)
+    }
+  ]
+})
+</script>
+
+<template>
+  <main
+    id="main"
+    class="page"
+  >
+    <SectionWrapper>
+      <h1>{{ page.title }}</h1>
+      <pre style="text-wrap: auto;">{{ page }}</pre>
+      <DividerGeneral />
+      <h2>Collection Count: {{ collection.length }}</h2>
+      <p>Displaying first 10</p>
+      <pre style="text-wrap: auto;">{{ collection.slice(0, 10) }}</pre>
+    </SectionWrapper>
+  </main>
+</template>


### PR DESCRIPTION
Connected to [APPS-3290](https://jira.library.ucla.edu/browse/APPS-3290)

**Pages Created:** /pages/collections/motion-picture.vue

**Preview Routes:**
- Motion Picture: https://deploy-preview-135--test-ftva.netlify.app/collections/motion-picture
- Television: https://deploy-preview-135--test-ftva.netlify.app/collections/television
- Watch Listen Online: https://deploy-preview-135--test-ftva.netlify.app/collections/watch-listen-online

**Notes:**
- Added GQL query for Collections Listing singles
- Setup route aliases
- Basic page setup: useHead, preview logic, raw data for testing

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I assigned this PR to someone to review
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~



[APPS-3290]: https://uclalibrary.atlassian.net/browse/APPS-3290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ