### PR TITLE
feat: APPS-3301 Add CollectionListing composable

### DIFF
--- a/composables/useCollectionListSearch.js
+++ b/composables/useCollectionListSearch.js
@@ -1,0 +1,71 @@
+export default function useCollectionListSearch() {
+  return { paginatedCollectionListQuery }
+}
+
+async function paginatedCollectionListQuery(
+  collectionType,
+  currentPage = 1,
+  documentsPerPage = 10,
+  source = ['*'],
+) {
+  const config = useRuntimeConfig()
+  if (
+    config.public.esReadKey === '' ||
+        config.public.esURL === '' ||
+        config.public.esAlias === ''
+  )
+    return
+
+  const response = await fetch(
+    `${config.public.esURL}/${config.public.esAlias}/_search`,
+    {
+      headers: {
+        Authorization: `ApiKey ${config.public.esReadKey}`,
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      body: JSON.stringify({
+        from: (currentPage - 1) * documentsPerPage,
+        size: documentsPerPage,
+        _source: [...source],
+        query: {
+          bool: {
+            filter: [
+              {
+                term: {
+                  'sectionHandle.keyword': 'ftvaCollection'
+                }
+              },
+              ...parseCollectionType(collectionType)
+            ]
+          },
+        },
+        sort: [
+          {
+            'title.keyword': {
+              order: 'asc'
+            }
+          }
+        ]
+      }),
+    }
+  )
+
+  const data = await response.json()
+  return data
+}
+
+function parseCollectionType(collectionType) {
+  if (collectionType && collectionType === '') return []
+
+  const boolQuery = []
+
+  const collectionTypeQueryObj = {}
+  const key = 'ftvaCollectionType.keyword'
+  collectionTypeQueryObj.term = {}
+  collectionTypeQueryObj.term[key] = collectionType
+
+  boolQuery.push(collectionTypeQueryObj)
+
+  return boolQuery
+}

--- a/composables/useCollectionListSearch.js
+++ b/composables/useCollectionListSearch.js
@@ -5,7 +5,8 @@ export default function useCollectionListSearch() {
 async function paginatedCollectionListQuery(
   collectionType,
   currentPage = 1,
-  documentsPerPage = 10,
+  documentsPerPage = 12,
+  extraFilters,
   source = ['*'],
 ) {
   const config = useRuntimeConfig()
@@ -37,6 +38,15 @@ async function paginatedCollectionListQuery(
                 }
               },
               ...parseCollectionType(collectionType)
+            ],
+            must: [
+              {
+                wildcard: {
+                  'title.keyword': {
+                    value: extraFilters
+                  }
+                }
+              }
             ]
           },
         },

--- a/gql/queries/FTVACollectionTypeListing.gql
+++ b/gql/queries/FTVACollectionTypeListing.gql
@@ -1,6 +1,6 @@
 #import "../gql/fragments/Image.gql"
 
-query FTVACollectionsListing($section: [String!], $collectionType: [QueryArgument]) {
+query FTVACollectionsListing($section: [String!]) {
   entry(section: $section) {
     id
     slug
@@ -27,17 +27,6 @@ query FTVACollectionsListing($section: [String!], $collectionType: [QueryArgumen
           }
         }
       }
-    }
-  }
-  entries(
-    section: "ftvaCollection"
-    orderBy: "title"
-    ftvaCollectionType: $collectionType
-  ) {
-    title
-    uri
-    ftvaImage {
-      ...Image
     }
   }
 }

--- a/pages/collections/motion-picture/index.vue
+++ b/pages/collections/motion-picture/index.vue
@@ -52,8 +52,10 @@ console.log('Page data: ', page.value)
 
 // TESTING ES
 const collectionType = ref(routeNameToSectionMap[route.path].collection)
+const collectionList = ref([])
 const currentPage = ref(1)
-const documentsPerPage = 10
+const documentsPerPage = 12
+const totalDocuments = ref()
 
 const { paginatedCollectionListQuery } = useCollectionListSearch()
 
@@ -64,8 +66,11 @@ onMounted(async () => {
     documentsPerPage,
   )
 
-  console.log('ES output total hits: ', esOutput.hits.total.value)
+  collectionList.value = esOutput.hits.hits
+  totalDocuments.value = esOutput.hits.total.value
 
+  // console.log('ES output: ', esOutput.hits.hits)
+  // console.log('ES output total hits: ', esOutput.hits.total.value)
   // Motion Picture route ==> 48
   // Television route ==> 26
   // Watch and Listen Online ==> 6
@@ -103,9 +108,9 @@ useHead({
       <h1>{{ page.title }}</h1>
       <pre style="text-wrap: auto;">{{ page }}</pre>
       <DividerGeneral />
-      <h2>Collection Count: ?</h2>
-      <p>Displaying first 10</p>
-      <!--<pre style="text-wrap: auto;">{{ xxx.slice(0, 10) }}</pre>-->
+      <h2>Collection Count (ES): {{ totalDocuments }}</h2>
+      <p>Returning 12 per page</p>
+      <pre style="text-wrap: auto;">{{ collectionList }}</pre>
     </SectionWrapper>
   </main>
 </template>

--- a/pages/collections/motion-picture/index.vue
+++ b/pages/collections/motion-picture/index.vue
@@ -72,7 +72,7 @@ async function testES() {
     extraFilters.value
   )
 
-  console.log('ES search: ', extraFilters.value)
+  console.log('Browse-by: ', extraFilters.value)
   collectionList.value = esOutput.hits.hits
   totalDocuments.value = esOutput.hits.total.value
 }
@@ -112,15 +112,21 @@ useHead({
   >
     <SectionWrapper>
       <h1>{{ page.title }}</h1>
-      <pre style="text-wrap: auto;">{{ page }}</pre>
+      <pre style="text-wrap: auto;">{{ page.summary }}</pre>
+      <DividerGeneral />
+      <h2>Associated General Content Pages (Titles)</h2>
+      <pre
+        style="text-wrap: auto;">{{page.associatedGeneralContentPagesFtva.map(page => page.title)}}</pre>
       <DividerGeneral />
       <h2>Collection Count (ES): {{ totalDocuments }}</h2>
       <h3>Test Browse By Alphabet</h3>
-      <input
-        v-model="alphabet"
-        type="text"
-        placeholder="Enter a single alphabet"
-      >
+      <div>
+        <input
+          v-model="alphabet"
+          type="text"
+          placeholder="Enter a single alphabet"
+        >
+      </div>
       <p>Return 12 per page</p>
       <pre style="text-wrap: auto;">{{ collectionList }}</pre>
     </SectionWrapper>

--- a/pages/collections/motion-picture/index.vue
+++ b/pages/collections/motion-picture/index.vue
@@ -22,7 +22,7 @@ const routeNameToSectionMap = {
   },
   '/collections/watch-listen-online': {
     sectionName: 'ftvaListingWatchAndListenOnline',
-    collection: 'watch-listen-online'
+    collection: 'watchAndListenOnline'
   }
 }
 
@@ -49,9 +49,30 @@ if (!data.value.entry) {
 // DATA
 const page = ref(_get(data.value, 'entry', {}))
 const collection = ref(_get(data.value, 'entries', {}))
+const collectionType = ref(routeNameToSectionMap[route.path].collection)
 
 console.log('page data: ', page.value)
 console.log('collection data: ', collection.value)
+
+const currentPage = ref(1)
+const documentsPerPage = 10
+
+// TESTING ES
+const { paginatedCollectionListQuery } = useCollectionListSearch()
+
+onMounted(async () => {
+  const esOutput = await paginatedCollectionListQuery(
+    collectionType.value,
+    currentPage.value,
+    documentsPerPage,
+  )
+
+  console.log('ES output total hits: ', esOutput.hits.total.value)
+
+  // Motion Picture route ==> 48
+  // Television route ==> 26
+  // Watch and Listen Online ==> 6
+})
 
 // PREVIEW WATCHER FOR CRAFT CONTENT
 watch(data, (newVal, oldVal) => {

--- a/pages/collections/motion-picture/index.vue
+++ b/pages/collections/motion-picture/index.vue
@@ -28,7 +28,7 @@ const routeNameToSectionMap = {
 
 const { data, error } = await useAsyncData(route.path, async () => {
   // lookup section based on routeNameToSectionMap
-  const data = await $graphql.default.request(FTVACollectionTypeListing, { section: routeNameToSectionMap[route.path].sectionName, collectionType: routeNameToSectionMap[route.path].collection })
+  const data = await $graphql.default.request(FTVACollectionTypeListing, { section: routeNameToSectionMap[route.path].sectionName })
   return data
 })
 
@@ -48,16 +48,13 @@ if (!data.value.entry) {
 
 // DATA
 const page = ref(_get(data.value, 'entry', {}))
-const collection = ref(_get(data.value, 'entries', {}))
+console.log('Page data: ', page.value)
+
+// TESTING ES
 const collectionType = ref(routeNameToSectionMap[route.path].collection)
-
-console.log('page data: ', page.value)
-console.log('collection data: ', collection.value)
-
 const currentPage = ref(1)
 const documentsPerPage = 10
 
-// TESTING ES
 const { paginatedCollectionListQuery } = useCollectionListSearch()
 
 onMounted(async () => {
@@ -77,7 +74,6 @@ onMounted(async () => {
 // PREVIEW WATCHER FOR CRAFT CONTENT
 watch(data, (newVal, oldVal) => {
   page.value = _get(newVal, 'entry', {})
-  collection.value = _get(newVal, 'entries', [])
 })
 
 definePageMeta({
@@ -107,9 +103,9 @@ useHead({
       <h1>{{ page.title }}</h1>
       <pre style="text-wrap: auto;">{{ page }}</pre>
       <DividerGeneral />
-      <h2>Collection Count: {{ collection.length }}</h2>
+      <h2>Collection Count: ?</h2>
       <p>Displaying first 10</p>
-      <pre style="text-wrap: auto;">{{ collection.slice(0, 10) }}</pre>
+      <!--<pre style="text-wrap: auto;">{{ xxx.slice(0, 10) }}</pre>-->
     </SectionWrapper>
   </main>
 </template>

--- a/pages/collections/motion-picture/index.vue
+++ b/pages/collections/motion-picture/index.vue
@@ -56,24 +56,30 @@ const collectionList = ref([])
 const currentPage = ref(1)
 const documentsPerPage = 12
 const totalDocuments = ref()
+const extraFilters = ref('*')
+const alphabet = ref()
 
-const { paginatedCollectionListQuery } = useCollectionListSearch()
+onMounted(() => {
+  testES()
+})
 
-onMounted(async () => {
+async function testES() {
+  const { paginatedCollectionListQuery } = useCollectionListSearch()
   const esOutput = await paginatedCollectionListQuery(
     collectionType.value,
     currentPage.value,
     documentsPerPage,
+    extraFilters.value
   )
 
+  console.log('ES search: ', extraFilters.value)
   collectionList.value = esOutput.hits.hits
   totalDocuments.value = esOutput.hits.total.value
+}
 
-  // console.log('ES output: ', esOutput.hits.hits)
-  // console.log('ES output total hits: ', esOutput.hits.total.value)
-  // Motion Picture route ==> 48
-  // Television route ==> 26
-  // Watch and Listen Online ==> 6
+watch(alphabet, (newVal, oldVal) => {
+  extraFilters.value = `${newVal.toUpperCase()}*`
+  testES()
 })
 
 // PREVIEW WATCHER FOR CRAFT CONTENT
@@ -109,7 +115,13 @@ useHead({
       <pre style="text-wrap: auto;">{{ page }}</pre>
       <DividerGeneral />
       <h2>Collection Count (ES): {{ totalDocuments }}</h2>
-      <p>Returning 12 per page</p>
+      <h3>Test Browse By Alphabet</h3>
+      <input
+        v-model="alphabet"
+        type="text"
+        placeholder="Enter a single alphabet"
+      >
+      <p>Return 12 per page</p>
       <pre style="text-wrap: auto;">{{ collectionList }}</pre>
     </SectionWrapper>
   </main>


### PR DESCRIPTION
Connected to [APPS-3301](https://jira.library.ucla.edu/browse/APPS-3301)

**Page Updated:** /pages/collections/motion-picture/index.vue

**Notes:**
- Setup new composable to fetch collectionType data for Collection Listing Type template from ElasticSearch
- Tested composable output (including output for user interaction with browse-by-alphabet scenario):
  - Motion Picture: https://deploy-preview-143--test-ftva.netlify.app/collections/motion-picture
  - Television: https://deploy-preview-143--test-ftva.netlify.app/collections/television
  - Watch and Listen Online: https://deploy-preview-143--test-ftva.netlify.app/collections/watch-listen-online
- Removed collectionType query from gql 
- **Testing code will be cleaned up (renamed, refactored, etc...) for page assembly**

**Checklist:**

-   [x] I added github label for semantic versioning
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~
-   [x] I assigned this PR to someone to review


[APPS-3301]: https://uclalibrary.atlassian.net/browse/APPS-3301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ