### PR TITLE
fix: APPS-3324 Restore VideoEmbed element after Craft fix

### DIFF
--- a/pages/collections/[collectionSlug]/[slug].vue
+++ b/pages/collections/[collectionSlug]/[slug].vue
@@ -244,14 +244,12 @@ useHead({
           :aspect-ratio="56.9"
           :controls="true"
         >
-          {{ page.videoEmbed }}
-          <!-- TODO UNCOMMENT THIS AFTER THE DATA IS FIXED FOR PAGE.VIDEOEMBED IN CRAFT as we are getting 500 error-->
-          <!--template #default>
+          <template #default>
             <VideoEmbed
               :trailer="page.videoEmbed"
               :poster-image="page.ftvaImage[0]"
             />
-          </template-->
+          </template>
         </ResponsiveVideo>
         <ResponsiveImage
           v-else


### PR DESCRIPTION
Connected to [APPS-3324](https://jira.library.ucla.edu/browse/APPS-3324)

**Page updated:** /collections/[collectionSlug]/[slug].vue

**Notes:**

- Replaced temporary videoEmbed code with VideoEmbed component after data fix in Craft

**Checklist:**

-   [x] I added github label for semantic versioning
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~
-   [x] I assigned this PR to someone to review


[APPS-3324]: https://uclalibrary.atlassian.net/browse/APPS-3324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ