### PR TITLE
fix: render basicCollections without infoblock text data

### DIFF
--- a/components/BasicCollection.vue
+++ b/components/BasicCollection.vue
@@ -228,9 +228,10 @@ useHead({
           v-if="page.videoEmbed"
           :trailer="page.videoEmbed"
         />
-        <DividerWayFinder v-if="parsedInfoBlock" />
+        <!-- TODO APPS-3326 can remove the '&& parsedInfoBlock.text' condition when we have a way to support Contact Info Data in this spot -->
+        <DividerWayFinder v-if="parsedInfoBlock && parsedInfoBlock.text" />
         <div
-          v-if="parsedInfoBlock"
+          v-if="parsedInfoBlock && parsedInfoBlock.text"
           class="cta-block"
         >
           <BlockCallToAction


### PR DESCRIPTION
**Notes:**

A temporary fix to prevent page render errors when InfoBlock data is not formed the way we expect.
Created https://uclalibrary.atlassian.net/browse/APPS-3326 to capture more robust requirements for supporting new type of InfoBlock
