### PR TITLE
feat: APPS-3315 Create Storytelling template GraphQL

### DIFF
--- a/components/StorytellingCollection.vue
+++ b/components/StorytellingCollection.vue
@@ -1,4 +1,0 @@
-<script>
-// storytelling collection layout can be built here
-// then loaded into the collections/[slug].vue page using dynamic components
-</script>

--- a/cypress/e2e/collectionItemDetailPage.cy.js
+++ b/cypress/e2e/collectionItemDetailPage.cy.js
@@ -1,6 +1,6 @@
 describe('Collection Item Detail Page', () => {
   it('Visits a Collection Item Detail Page', () => {
-    cy.visit('/collections/la-rebellion/grey-area')
+    cy.visit('/collections/ktla-newsfilm-collection/african-american-william-c-taylor-of-the-communist-party-to-run-for-los-angeles-county-supervisor')
     cy.getByData('breadcrumb').should('be.visible')
     cy.getByData('page-title').should('be.visible')
     cy.getByData('metadata').should('be.visible')

--- a/gql/fragments/BlockCardWithImageFragment.gql
+++ b/gql/fragments/BlockCardWithImageFragment.gql
@@ -3,6 +3,7 @@ fragment BlockCardWithImageFragment on ElementInterface {
   typeHandle
   sectionTitle: titleGeneral
   sectionSummary: summary
+  ftvaFlexibilePageBlockCardWithImageType
   cardWithImage: ftvaFlexiblePageBlock_cardWithImage {
     id
     ... on ftvaFlexiblePageBlock_cardWithImage_internalContent_BlockType {

--- a/gql/fragments/collections/AllFtvaFpb.gql
+++ b/gql/fragments/collections/AllFtvaFpb.gql
@@ -14,7 +14,6 @@ fragment AllFtvaFpb on ElementInterface {
     blocks: allFtvaFpb {
         id
         typeHandle
-        ftvaFlexibilePageBlockCardWithImageType
 
         ... on allFtvaFpb_callToAction_BlockType {
             ...BlockCallToActionFragment

--- a/gql/fragments/collections/AllFtvaFpb.gql
+++ b/gql/fragments/collections/AllFtvaFpb.gql
@@ -14,6 +14,7 @@ fragment AllFtvaFpb on ElementInterface {
     blocks: allFtvaFpb {
         id
         typeHandle
+        ftvaFlexibilePageBlockCardWithImageType
 
         ... on allFtvaFpb_callToAction_BlockType {
             ...BlockCallToActionFragment

--- a/gql/queries/FTVACollectionStory.gql
+++ b/gql/queries/FTVACollectionStory.gql
@@ -1,0 +1,26 @@
+#import "../gql/fragments/collections/AllFtvaFpb.gql"
+#import "../gql/fragments/Image.gql"
+
+
+query FTVACollectionStory($slug: [String!]){
+  entry(section: "ftvaCollectionStory", slug:$slug) {
+    id
+    slug
+    uri
+    sectionHandle
+    title
+    summary
+    ftvaImage {
+      ...Image
+    }
+    imageCarousel {
+      ... on imageCarousel_imageCarousel_BlockType {
+        image {
+          ...Image
+        }
+        creditText
+      }
+    }
+    ...AllFtvaFpb
+  }
+}

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -6,7 +6,7 @@ import _get from 'lodash/get'
 import FTVACollectionLayoutType from '../gql/queries/FTVACollectionType.gql'
 
 // CHILD COMPONENTS
-import { BasicCollection, ListOfItemsCollection, StorytellingCollection } from '#components'
+import { BasicCollection, ListOfItemsCollection } from '#components'
 
 const { $graphql } = useNuxtApp()
 
@@ -43,8 +43,6 @@ const pageType = computed(() => {
   const collectionpagetype = _get(data.value, 'ftvaCollection.ftvaCollectionLayoutType', 'basic')
   if (collectionpagetype === 'listOfItems') {
     return ListOfItemsCollection
-  } else if (collectionpagetype === 'storytelling') {
-    return StorytellingCollection
   } else {
     return BasicCollection // default to basic
   }

--- a/pages/collections/la-rebellion/index.vue
+++ b/pages/collections/la-rebellion/index.vue
@@ -1,0 +1,80 @@
+<script setup>
+
+// HELPERS
+import _get from 'lodash/get'
+
+// GQL
+import FTVACollectionStory from '../gql/queries/FTVACollectionStory.gql'
+
+const { $graphql } = useNuxtApp()
+
+const route = useRoute()
+console.log('route path: ', route.path)
+
+// routes this page supports:
+const routeNameToSlugMap = {
+  '/collections/la-rebellion': 'la-rebellion-2',
+  // '/collections/in-the-life': 'in-the-life'
+}
+
+console.log('slug: ', routeNameToSlugMap[route.path])
+
+const { data, error } = await useAsyncData(`collections-story-${route.path}`, async () => {
+  // lookup slug based on routeNameToSlugMap
+  const data = await $graphql.default.request(FTVACollectionStory, { slug: routeNameToSlugMap[route.path] })
+  return data
+})
+
+console.log('data: ', data.value)
+
+// if (error.value) {
+//   console.log(route)
+//   throw createError({
+//     ...error.value, statusMessage: 'Page not found.' + error.value, fatal: true
+//   })
+// }
+
+// if (!data.value.entry) {
+//   console.log(route)
+//   throw createError({
+//     statusCode: 404,
+//     statusMessage: 'Page Not Found',
+//     fatal: true
+//   })
+// }
+
+// DATA
+// const page = ref(_get(data.value, 'entry', {}))
+
+// console.log('page data: ', page.value)
+
+// PREVIEW WATCHER FOR CRAFT CONTENT
+// watch(data, (newVal, oldVal) => {
+//   page.value = _get(newVal, 'entry', {})
+// })
+
+// useHead({
+//   title: page.value ? page.value.title : '... loading',
+//   meta: [
+//     {
+//       hid: 'description',
+//       name: 'description',
+//       content: removeTags(page.value.summary)
+//     }
+//   ]
+// })
+</script>
+
+<template>
+  <main
+    id="main"
+    class="page"
+  >
+    <SectionWrapper>
+      <h2>Page</h2>
+      <!-- <h1>{{ page.title }}</h1>
+      <pre style="text-wrap: auto;">{{ page }}</pre> -->
+      <DividerGeneral />
+    </SectionWrapper>
+  </main>
+</template>

--- a/pages/collections/la-rebellion/index.vue
+++ b/pages/collections/la-rebellion/index.vue
@@ -13,7 +13,7 @@ console.log('route path: ', route.path)
 
 // routes this template/page supports:
 const routeNameToSlugMap = {
-  '/collections/la-rebellion': 'la-rebellion-2',
+  '/collections/la-rebellion': 'la-rebellion',
   '/collections/in-the-life': 'in-the-life'
 }
 

--- a/pages/collections/la-rebellion/index.vue
+++ b/pages/collections/la-rebellion/index.vue
@@ -11,10 +11,10 @@ const { $graphql } = useNuxtApp()
 const route = useRoute()
 console.log('route path: ', route.path)
 
-// routes this page supports:
+// routes this template/page supports:
 const routeNameToSlugMap = {
   '/collections/la-rebellion': 'la-rebellion-2',
-  // '/collections/in-the-life': 'in-the-life'
+  '/collections/in-the-life': 'in-the-life'
 }
 
 console.log('slug: ', routeNameToSlugMap[route.path])
@@ -25,44 +25,40 @@ const { data, error } = await useAsyncData(`collections-story-${route.path}`, as
   return data
 })
 
-console.log('data: ', data.value)
+if (error.value) {
+  throw createError({
+    ...error.value, statusMessage: 'Page not found.' + error.value, fatal: true
+  })
+}
 
-// if (error.value) {
-//   console.log(route)
-//   throw createError({
-//     ...error.value, statusMessage: 'Page not found.' + error.value, fatal: true
-//   })
-// }
-
-// if (!data.value.entry) {
-//   console.log(route)
-//   throw createError({
-//     statusCode: 404,
-//     statusMessage: 'Page Not Found',
-//     fatal: true
-//   })
-// }
+if (!data.value.entry) {
+  throw createError({
+    statusCode: 404,
+    statusMessage: 'Page Not Found',
+    fatal: true
+  })
+}
 
 // DATA
-// const page = ref(_get(data.value, 'entry', {}))
+const page = ref(_get(data.value, 'entry', {}))
 
-// console.log('page data: ', page.value)
+console.log('page data: ', page.value)
 
 // PREVIEW WATCHER FOR CRAFT CONTENT
-// watch(data, (newVal, oldVal) => {
-//   page.value = _get(newVal, 'entry', {})
-// })
+watch(data, (newVal, oldVal) => {
+  page.value = _get(newVal, 'entry', {})
+})
 
-// useHead({
-//   title: page.value ? page.value.title : '... loading',
-//   meta: [
-//     {
-//       hid: 'description',
-//       name: 'description',
-//       content: removeTags(page.value.summary)
-//     }
-//   ]
-// })
+useHead({
+  title: page.value ? page.value.title : '... loading',
+  meta: [
+    {
+      hid: 'description',
+      name: 'description',
+      content: removeTags(page.value.summary)
+    }
+  ]
+})
 </script>
 
 <template>
@@ -71,9 +67,8 @@ console.log('data: ', data.value)
     class="page"
   >
     <SectionWrapper>
-      <h2>Page</h2>
-      <!-- <h1>{{ page.title }}</h1>
-      <pre style="text-wrap: auto;">{{ page }}</pre> -->
+      <h1>{{ page.title }}</h1>
+      <pre style="text-wrap: auto;">{{ page }}</pre>
       <DividerGeneral />
     </SectionWrapper>
   </main>

--- a/pages/collections/la-rebellion/index.vue
+++ b/pages/collections/la-rebellion/index.vue
@@ -49,6 +49,12 @@ watch(data, (newVal, oldVal) => {
   page.value = _get(newVal, 'entry', {})
 })
 
+definePageMeta({
+  layout: 'default',
+  path: '/collections/la-rebellion',
+  alias: ['/collections/in-the-life']
+})
+
 useHead({
   title: page.value ? page.value.title : '... loading',
   meta: [


### PR DESCRIPTION
Connected to [APPS-3315](https://jira.library.ucla.edu/browse/APPS-3315)

**Page Created:** /pages/collections/la-rebellion/index.vue

**Notes:**

- Created query for `ftvaCollectionStory` type
- Updated ~~FlexibleBlocks query file~~ BlockCardWithImage fragment with field for CardWithImage block styling option
- Setup route aliases
- Basic page setup: useHead, preview logic, raw data for testing
- Deleted StoryTelling component; updated layout choice logic in `collections/[slug].vue`

**Preview:**

- https://deploy-preview-155--test-ftva.netlify.app/collections/la-rebellion
- https://deploy-preview-155--test-ftva.netlify.app/collections/in-the-life
  -  ~~No current entry for `In The Life` in the new collection type, so the collection is still using the default/basic template~~

**Checklist:**

-   [x] I added github label for semantic versioning
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~
-   [x] I have requested a PR review from the Dev team


[APPS-3315]: https://uclalibrary.atlassian.net/browse/APPS-3315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ