### PR TITLE
feat:  APPS-3336 setup new gql for filmography

### DIFF
--- a/gql/queries/FTVACollectionFilmography.gql
+++ b/gql/queries/FTVACollectionFilmography.gql
@@ -1,0 +1,9 @@
+# options "ftvaCollectionListingLARebellion"
+query FTVACollectionFilmography($section: [String!]) {
+ entry(section:$section) {
+  id
+  title: titleGeneral
+  ftvaHomepageDescription: summary
+  ftvaFilters
+ }
+}

--- a/pages/collections/la-rebellion/filmography/index.vue
+++ b/pages/collections/la-rebellion/filmography/index.vue
@@ -1,0 +1,77 @@
+<script lang="ts" setup>
+
+// HELPERS
+import _get from 'lodash/get'
+
+// GQL
+import FTVACollectionFilmography from '../gql/queries/FTVACollectionFilmography.gql'
+import ListOfItemsCollection from '~/components/ListOfItemsCollection.vue'
+
+const { $graphql } = useNuxtApp()
+
+const route = useRoute()
+console.log('route path: ', route.path)
+
+// routes this template/page supports:
+const routeNameToSectionMap = {
+  '/collections/la-rebellion/filmography': 'ftvaCollectionListingLARebellion',
+  '/collections/in-the-life/filmography': 'ftvaCollectionListingInTheLife'
+}
+
+// console.log('slug: ', routeNameToSlugMap[route.path])
+
+const { data, error } = await useAsyncData(`${route.path}-filmography`, async () => {
+  // lookup slug based on routeNameToSlugMap
+  const data = await $graphql.default.request(FTVACollectionFilmography, { section: routeNameToSectionMap[route.path] })
+  return data
+})
+
+if (error.value) {
+  throw createError({
+    ...error.value, statusMessage: 'Page not found.' + error.value, fatal: true
+  })
+}
+
+if (!data.value.entry) {
+  throw createError({
+    statusCode: 404,
+    statusMessage: 'Page Not Found',
+    fatal: true
+  })
+}
+
+// DATA
+const page = ref(_get(data.value, 'entry', {}))
+
+console.log('page data: ', page.value)
+
+// PREVIEW WATCHER FOR CRAFT CONTENT
+watch(data, (newVal, oldVal) => {
+  page.value = _get(newVal, 'entry', {})
+})
+
+definePageMeta({
+  layout: 'default',
+  path: '/collections/la-rebellion/filmography',
+  alias: ['/collections/in-the-life/filmography']
+})
+
+useHead({
+  title: page.value ? page.value.title : '... loading',
+  meta: [
+    {
+      hid: 'description',
+      name: 'description',
+      content: removeTags(page.value.summary)
+    }
+  ]
+})
+</script>
+<template>
+  <!-- {{ page }} -->
+  <ListOfItemsCollection :page="page" />
+</template>
+<style scoped>
+/* TODO test w styles before creating own
+@import 'assets/styles/listing-pages.scss'; */
+</style>


### PR DESCRIPTION
Connected to [APPS-3336](https://jira.library.ucla.edu/browse/APPS-3336)

**Page/Pages Created/updated:** {filename}.vue from #{issue number}

**Notes:**

Created a gql query that can take a section name based on the route path to look data for the filmography pages

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   [X] I completed any required mobile breakpoint styling
-   [X] I completed any required hover state styling
-   [X] I included a working spec file
-   ~~[] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~
-   [X] I assigned this PR to someone to review
