### PR TITLE
fix: add style rule to offset links

### DIFF
--- a/assets/styles/slug-pages.scss
+++ b/assets/styles/slug-pages.scss
@@ -85,3 +85,13 @@
 :deep(.form .iframe) {
   max-width: 100%;
 }
+
+// adjust flexible block links to navigate below sticky header
+.flexible-blocks.flexible-content {
+  :deep(.section-wrapper) {
+    >a {
+      position: relative;
+      top: -70px; //offset links in the document by the height of the sticky header
+    }
+  }
+}

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -207,7 +207,6 @@ onMounted(() => {
   }
 
   // Flexible Blocks Rich Text Styles
-  // added during UX review of page 4/4/2025 - TODO move to FTVA FlexibleBlocks theme?
   .flexible-blocks.flexible-content {
 
     :deep(.section-wrapper) {


### PR DESCRIPTION
Connected to [APPS-3357](https://jira.library.ucla.edu/browse/APPS-3357)

**Notes:**

Added a style rule to the slug_pages.scss file so that anchors in flexibleBlocks will be offset by the height of the sticky header

Now pages with FlexibleBlocks & PageAnchor components should properly offset the link to appear below the sticky-header

**Time Report:**

This took me 1-2 hours to build this. Mostly process tasks to post code for review. 

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   [X] I added notes above about how long it took to build this component
-   [ ] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-3357]: https://uclalibrary.atlassian.net/browse/APPS-3357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ