### PR TITLE
feat: APPS-3097 Add Filmmakers Listing composable

### DIFF
--- a/composables/useFilmmakersListSearch.js
+++ b/composables/useFilmmakersListSearch.js
@@ -1,0 +1,62 @@
+export default function useFilmmakersListSearch() {
+  return { paginatedFilmmakersQuery }
+}
+
+async function paginatedFilmmakersQuery(
+  currentPage = 1,
+  documentsPerPage = 12,
+  sort,
+  orderBy,
+  source = ['*'],
+) {
+  const config = useRuntimeConfig()
+  if (
+    config.public.esReadKey === '' ||
+        config.public.esURL === '' ||
+        config.public.esAlias === ''
+  )
+    return
+
+  const response = await fetch(
+    `${config.public.esURL}/${config.public.esAlias}/_search`,
+    {
+      headers: {
+        Authorization: `ApiKey ${config.public.esReadKey}`,
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      body: JSON.stringify({
+        from: (currentPage - 1) * documentsPerPage,
+        size: documentsPerPage,
+        _source: [...source],
+        query: {
+          bool: {
+            filter: [
+              {
+                term: {
+                  'sectionHandle.keyword': 'ftvaLARebellionIndividual'
+                }
+              }
+            ]
+          },
+        },
+        ...parseSort(sort, orderBy),
+      }),
+    }
+  )
+
+  const data = await response.json()
+  return data
+}
+
+function parseSort(sortField, orderBy = 'asc') {
+  if (!sortField || sortField === '') return {}
+  const parseQuery = {}
+  parseQuery.sort = []
+  parseQuery.sort[0] = {}
+  parseQuery.sort[0][sortField] = {
+    order: orderBy
+  }
+
+  return parseQuery
+}

--- a/gql/queries/FTVALARebellionFilmmakersList.gql
+++ b/gql/queries/FTVALARebellionFilmmakersList.gql
@@ -7,16 +7,4 @@ query FTVALARebellionFilmmakersList {
     summary
     displaySummary
   }
-  entries(section: ["ftvaLARebellionIndividual"], orderBy: "postDate DESC") {
-    id
-    to: uri
-    typeHandle
-    sectionHandle
-    postDate
-    title
-    richText
-    associatedFilms {
-      titleGeneral
-    }
-  }
 }

--- a/gql/queries/FTVALARebellionFilmmakersList.gql
+++ b/gql/queries/FTVALARebellionFilmmakersList.gql
@@ -3,7 +3,7 @@ query FTVALARebellionFilmmakersList {
     id
     typeHandle
     sectionHandle
-    titleGeneral
+    title: titleGeneral
     summary
     displaySummary
   }

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -1,7 +1,6 @@
 <script setup>
 // HELPERS
 import _get from 'lodash/get'
-import { useWindowSize, useInfiniteScroll } from '@vueuse/core'
 import FTVAArticleList from '../gql/queries/FTVAArticleList.gql'
 import useMobileOnlyInfiniteScroll from '@/composables/useMobileOnlyInfiniteScroll'
 

--- a/pages/collections/la-rebellion/filmmakers/index.vue
+++ b/pages/collections/la-rebellion/filmmakers/index.vue
@@ -88,7 +88,7 @@ onMounted(async () => {
   const esOutput = await paginatedFilmmakersQuery(
     currentPage.value,
     documentsPerPage,
-    'postDate',
+    'title.keyword',
     'asc'
   )
 

--- a/pages/collections/la-rebellion/filmmakers/index.vue
+++ b/pages/collections/la-rebellion/filmmakers/index.vue
@@ -30,8 +30,6 @@ if (!data.value.entry) {
   })
 }
 
-// const route = useRoute()
-
 if (data.value.entry && import.meta.prerender) {
   try {
     // Call the composable to use the indexing function
@@ -43,7 +41,6 @@ if (data.value.entry && import.meta.prerender) {
       uri: '/collections/la-rebellion/filmmakers/',
       sectionHandle: data.value.entry.sectionHandle,
       groupName: 'Collections',
-      // postDate: data.value.entry.postDate,
     }
 
     // Index the event data using the composable during static build
@@ -57,7 +54,6 @@ if (data.value.entry && import.meta.prerender) {
 }
 
 const page = ref(_get(data.value, 'entry', {}))
-
 console.log('page: ', page.value)
 
 watch(data, (newVal, oldVal) => {
@@ -80,6 +76,29 @@ useHead({
     }
   ]
 })
+
+// TESTING COMPOSABLE
+const currentPage = ref(1)
+const documentsPerPage = 12
+const totalDocuments = ref()
+const filmmakers = ref([])
+const { paginatedFilmmakersQuery } = useFilmmakersListSearch()
+
+onMounted(async () => {
+  const esOutput = await paginatedFilmmakersQuery(
+    currentPage.value,
+    documentsPerPage,
+    'postDate',
+    'asc'
+  )
+
+  totalDocuments.value = esOutput.hits.total.value
+  filmmakers.value = esOutput.hits.hits
+
+  console.log('ES current page hits: ', esOutput.hits.hits) // 12
+  console.log('ES total hits: ', esOutput.hits.total.value) // 327
+})
+
 </script>
 
 <template>
@@ -87,23 +106,26 @@ useHead({
     class="page page-filmmakers"
     style="padding: 25px 100px;"
   >
-    <section-wrapper section-title="LA Rebellion Filmmakers">
+    <SectionWrapper section-title="LA Rebellion Filmmakers">
       <template v-if="showSummary">
         <RichText :rich-text-content="page.summary" />
       </template>
-      <!--<div
-        v-for="filmmaker in filmmakers"
-        :key="filmmaker?.id"
+      <DividerWayFinder />
+      <h2>Filmmaker Listing Count: {{ totalDocuments }}</h2>
+      <br>
+      <h3>First {{ documentsPerPage }} entries:</h3>
+      <br>
+      <div
+        v-for="filmmaker, index in filmmakers"
+        :key="index"
       >
-        <NuxtLink :to="`/${filmmaker?.to}`">
-          {{ filmmaker?.title }}
-        </NuxtLink> <br>
-        <h4>to: <code>{{ filmmaker?.to }}</code></h4>
-        <h4>richText: <code>{{ filmmaker?.richText }}</code></h4>
-        <h4>associatedFilms: <code>{{ filmmaker?.associatedFilms }}</code></h4>
-        <divider-general />
-      </div>-->
-    </section-wrapper>
+        <NuxtLink :to="`/${filmmaker?._source.to}`">
+          <h3>{{ filmmaker?._source.title }}</h3>
+        </NuxtLink>
+        <p>{{ filmmaker?._source.richText }}</p>
+        <DividerGeneral />
+      </div>
+    </SectionWrapper>
   </div>
 </template>
 

--- a/pages/collections/la-rebellion/filmmakers/index.vue
+++ b/pages/collections/la-rebellion/filmmakers/index.vue
@@ -67,7 +67,7 @@ const showSummary = computed(() => {
 })
 
 useHead({
-  title: page.value?.title || '... loading',
+  title: page.value ? page.value.title : '... loading',
   meta: [
     {
       hid: 'description',
@@ -106,7 +106,7 @@ onMounted(async () => {
     class="page page-filmmakers"
     style="padding: 25px 100px;"
   >
-    <SectionWrapper section-title="LA Rebellion Filmmakers">
+    <SectionWrapper :section-title="page.title">
       <template v-if="showSummary">
         <RichText :rich-text-content="page.summary" />
       </template>
@@ -116,8 +116,8 @@ onMounted(async () => {
       <h3>First {{ documentsPerPage }} entries:</h3>
       <br>
       <div
-        v-for="filmmaker, index in filmmakers"
-        :key="index"
+        v-for="filmmaker in filmmakers"
+        :key="filmmaker?._source.id"
       >
         <NuxtLink :to="`/${filmmaker?._source.to}`">
           <h3>{{ filmmaker?._source.title }}</h3>


### PR DESCRIPTION
Connected to [APPS-3095](https://jira.library.ucla.edu/browse/APPS-3095), [APPS-3097](https://jira.library.ucla.edu/browse/APPS-3097)

**Page updated:** /pages/collections/la-rebellion/filmmaker/index.vue

**Notes:**
- Update graphQL file to only return single entry content
- Set up composable for LA Rebellion Filmmaker Listings data from ElasticSearch
- Tested composable output

**Preview:** https://deploy-preview-183--test-ftva.netlify.app/collections/la-rebellion/filmmakers/

**Checklist:**

-   [x] I added github label for semantic versioning
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~
-   [x] I requested a PR review from the Dev team


[APPS-3095]: https://uclalibrary.atlassian.net/browse/APPS-3095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPS-3097]: https://uclalibrary.atlassian.net/browse/APPS-3097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ