### PR TITLE
fix: APPS-3212 pagination skipping on last page on desktop

### DIFF
--- a/components/ListOfItemsCollection.vue
+++ b/components/ListOfItemsCollection.vue
@@ -5,6 +5,7 @@ import { useCollectionAggregator } from '../composables/useCollectionAggregator'
 import config from '~/utils/searchConfig'
 import normalizeTitleForAlphabeticalBrowse from '~/utils/normalizeTitleForAlphabeticalBrowseBy'
 import useMobileOnlyInfiniteScroll from '@/composables/useMobileOnlyInfiniteScroll'
+import usePaginationScroll from '@/composables/usePaginationScroll'
 
 const attrs = useAttrs() as { page?: { title: string, ftvaFilters: string[], ftvaHomepageDescription: string, titleBrowse: string, groupName: string } }
 
@@ -80,6 +81,9 @@ const onResults = (results) => {
 
 // INFINITE SCROLL
 const { isLoading, isMobile, hasMore, desktopItemList, mobileItemList, totalPages, currentPage, currentList, scrollElem, searchES } = useMobileOnlyInfiniteScroll(collectionFetchFunction, onResults)
+
+// PAGINATION SCROLL HANDLING
+const { restoreScrollPosition } = usePaginationScroll('collection-items-section-title')
 
 // Format search results for SectionTeaserCard
 const parsedCollectionResults = computed(() => {
@@ -242,6 +246,9 @@ watch(
     selectedSortFilters.value = { sortField: Array.isArray(route.query.sort) ? route.query.sort[0] : (route.query.sort || 'asc') }
     currentPage.value = route.query.page ? parseInt(route.query.page as string) : 1
     searchES()
+
+    // Restore scroll position
+    restoreScrollPosition()
   }, { deep: true, immediate: true }
 )
 
@@ -270,6 +277,7 @@ useHead({
         to="/collections"
       />
       <SectionWrapper
+        id="collection-items-section-title"
         ref="scrollElem"
         :section-title="attrs.page.title"
         class="header"

--- a/composables/useMobileOnlyInfiniteScroll.ts
+++ b/composables/useMobileOnlyInfiniteScroll.ts
@@ -70,7 +70,7 @@ export default function useMobileInfiniteScroll<T = any>(
         await searchES()
       }
     },
-    { 
+    {
       distance: 100,
       canLoadMore: () => {
         // Only allow infinite scroll on mobile and when there's more content

--- a/composables/useMobileOnlyInfiniteScroll.ts
+++ b/composables/useMobileOnlyInfiniteScroll.ts
@@ -70,13 +70,7 @@ export default function useMobileInfiniteScroll<T = any>(
         await searchES()
       }
     },
-    {
-      distance: 100,
-      canLoadMore: () => {
-        // Only allow infinite scroll on mobile and when there's more content
-        return isMobile.value && hasMore.value && !isLoading.value
-      }
-    }
+    { distance: 100 }
   )
 
   // HANDLE WINDOW SIZING

--- a/composables/useMobileOnlyInfiniteScroll.ts
+++ b/composables/useMobileOnlyInfiniteScroll.ts
@@ -70,7 +70,13 @@ export default function useMobileInfiniteScroll<T = any>(
         await searchES()
       }
     },
-    { distance: 100 }
+    { 
+      distance: 100,
+      canLoadMore: () => {
+        // Only allow infinite scroll on mobile and when there's more content
+        return isMobile.value && hasMore.value && !isLoading.value
+      }
+    }
   )
 
   // HANDLE WINDOW SIZING

--- a/composables/usePaginationScroll.ts
+++ b/composables/usePaginationScroll.ts
@@ -1,0 +1,38 @@
+/**
+ * Composable for handling scroll position restoration during pagination
+ * @param {string} elementId - The ID of the element to scroll to after pagination
+ * @returns {Object} - Object containing savedScrollPosition ref and restoreScrollPosition function
+ */
+export default function usePaginationScroll(elementId: string) {
+  // Track scroll position for pagination
+  const savedScrollPosition = ref<number>(0)
+
+  // Save scroll position before route update
+  onBeforeRouteUpdate((to, from) => {
+    if (to.query.page !== from.query.page) {
+      savedScrollPosition.value = window.scrollY
+    }
+  })
+
+  // Function to restore scroll position
+  const restoreScrollPosition = (): void => {
+    if (savedScrollPosition.value > 0) {
+      console.log('Restoring scroll position:', savedScrollPosition.value)
+      nextTick(() => {
+        setTimeout(() => {
+          // scroll to the specified element
+          const targetElement = document.getElementById(elementId)
+          if (targetElement) {
+            targetElement.scrollIntoView({ behavior: 'smooth' })
+          }
+          savedScrollPosition.value = 0 // Reset after restoration
+        }, 250) // 250ms delay to ensure content is loaded
+      })
+    }
+  }
+
+  return {
+    savedScrollPosition,
+    restoreScrollPosition
+  }
+}

--- a/composables/usePaginationScroll.ts
+++ b/composables/usePaginationScroll.ts
@@ -9,7 +9,9 @@ export default function usePaginationScroll(elementId: string) {
 
   // Save scroll position before route update
   onBeforeRouteUpdate((to, from) => {
+    console.log('onBeforeRouteUpdate', to, from)
     if (to.query.page !== from.query.page) {
+      console.log('Saving scroll position:', window.scrollY)
       savedScrollPosition.value = window.scrollY
     }
   })

--- a/error.vue
+++ b/error.vue
@@ -79,7 +79,9 @@ const isDevelopment = computed(() => import.meta.dev)
             further assistance, please <nuxt-link
               class="link"
               to="/contact"
-            >contact us</nuxt-link>.
+            >
+              contact us
+            </nuxt-link>.
           </p>
         </div>
       </SectionWrapper>

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -107,7 +107,6 @@ const savedScrollPosition = ref(0)
 // Save scroll position before route update
 onBeforeRouteUpdate((to, from) => {
   if (to.query.page !== from.query.page) {
-    // console.log('Saving scroll position before navigation:', window.scrollY)
     savedScrollPosition.value = window.scrollY
   }
 })
@@ -115,10 +114,6 @@ onBeforeRouteUpdate((to, from) => {
 watch(
   () => route.query,
   (newVal, oldVal) => {
-    // console.log('In watch route query', newVal, oldVal)
-    // console.log('Current page:', currentPage.value, 'New page:', route.query.page ? parseInt(route.query.page) : 1)
-    // console.log('Is mobile:', isMobile.value)
-
     isLoading.value = false
 
     currentPage.value = route.query.page ? parseInt(route.query.page) : 1
@@ -129,23 +124,15 @@ watch(
     hasMore.value = true
     searchES()
 
-    // Restore scroll position with 100ms delay
+    // Restore scroll position
     if (savedScrollPosition.value > 0) {
       console.log('Restoring scroll position:', savedScrollPosition.value)
       nextTick(() => {
         setTimeout(() => {
-          // check total content height
-          const contentHeight = document.documentElement.scrollHeight
-          // const windowHeight = window.innerHeight
-          console.log('Total Content height:', contentHeight)
-          if (savedScrollPosition.value < contentHeight) {
-            window.scrollTo(0, savedScrollPosition.value)
-          } else {
-            // scroll to #blog-section-title
-            const blogSectionTitle = document.getElementById('blog-section-title')
-            if (blogSectionTitle) {
-              blogSectionTitle.scrollIntoView({ behavior: 'smooth' })
-            }
+          // scroll to #blog-section-title
+          const blogSectionTitle = document.getElementById('blog-section-title')
+          if (blogSectionTitle) {
+            blogSectionTitle.scrollIntoView({ behavior: 'smooth' })
           }
           savedScrollPosition.value = 0 // Reset after restoration
         }, 250) // 250ms delay to ensure content is loaded

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -3,6 +3,7 @@
 import _get from 'lodash/get'
 import FTVAArticleList from '../gql/queries/FTVAArticleList.gql'
 import useMobileOnlyInfiniteScroll from '@/composables/useMobileOnlyInfiniteScroll'
+import usePaginationScroll from '@/composables/usePaginationScroll.ts'
 
 // GQL
 const { $graphql } = useNuxtApp()
@@ -101,15 +102,8 @@ const onResults = (results) => {
 const documentsPerPage = 10
 const { isLoading, isMobile, hasMore, desktopItemList, mobileItemList, totalPages, currentPage, currentList, scrollElem, searchES } = await useMobileOnlyInfiniteScroll(articleFetchFunction, onResults)
 
-// Track scroll position for blog pagination
-const savedScrollPosition = ref(0)
-
-// Save scroll position before route update
-onBeforeRouteUpdate((to, from) => {
-  if (to.query.page !== from.query.page) {
-    savedScrollPosition.value = window.scrollY
-  }
-})
+// PAGINATION SCROLL HANDLING
+const { restoreScrollPosition } = usePaginationScroll('blog-section-title')
 
 watch(
   () => route.query,
@@ -125,19 +119,7 @@ watch(
     searchES()
 
     // Restore scroll position
-    if (savedScrollPosition.value > 0) {
-      console.log('Restoring scroll position:', savedScrollPosition.value)
-      nextTick(() => {
-        setTimeout(() => {
-          // scroll to #blog-section-title
-          const blogSectionTitle = document.getElementById('blog-section-title')
-          if (blogSectionTitle) {
-            blogSectionTitle.scrollIntoView({ behavior: 'smooth' })
-          }
-          savedScrollPosition.value = 0 // Reset after restoration
-        }, 250) // 250ms delay to ensure content is loaded
-      })
-    }
+    restoreScrollPosition()
   }, { deep: true, immediate: true }
 )
 

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -9,10 +9,7 @@ import useMobileOnlyInfiniteScroll from '@/composables/useMobileOnlyInfiniteScro
 const { $graphql } = useNuxtApp()
 
 const route = useRoute()
-const router = useRouter()
-
-// Store scroll position for blog pagination
-const savedScrollPosition = ref(0)
+// const router = useRouter()
 
 const { data, error } = await useAsyncData('article-list', async () => {
   const data = await $graphql.default.request(FTVAArticleList)
@@ -118,9 +115,12 @@ const onResults = (results) => {
 const documentsPerPage = 10
 const { isLoading, isMobile, hasMore, desktopItemList, mobileItemList, totalPages, currentPage, currentList, scrollElem, searchES } = await useMobileOnlyInfiniteScroll(articleFetchFunction, onResults)
 
-// Log scroll position before navigation
-router.beforeEach((to, from) => {
-  if (to.path === '/blog' && from.path === '/blog' && to.query.page !== from.query.page) {
+// Track scroll position for blog pagination
+const savedScrollPosition = ref(0)
+
+// Save scroll position before route update
+onBeforeRouteUpdate((to, from) => {
+  if (to.query.page !== from.query.page) {
     console.log('Saving scroll position before navigation:', window.scrollY)
     savedScrollPosition.value = window.scrollY
   }
@@ -154,9 +154,9 @@ watch(
         setTimeout(() => {
           // check total content height
           const contentHeight = document.documentElement.scrollHeight
-          const windowHeight = window.innerHeight
-          console.log('Content height:', contentHeight)
-          if (savedScrollPosition.value + windowHeight < contentHeight) {
+          // const windowHeight = window.innerHeight
+          console.log('Total Content height:', contentHeight)
+          if (savedScrollPosition.value < contentHeight) {
             window.scrollTo(0, savedScrollPosition.value)
           } else {
             // scroll to #blog-section-title
@@ -166,7 +166,7 @@ watch(
             }
           }
           savedScrollPosition.value = 0 // Reset after restoration
-        }, 100)
+        }, 250) // 250ms delay to ensure content is loaded
       })
     }
   }, { deep: true, immediate: true }

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -1,7 +1,6 @@
 <script setup>
 // HELPERS
 import _get from 'lodash/get'
-// import { useWindowSize, useInfiniteScroll } from '@vueuse/core'
 import FTVAArticleList from '../gql/queries/FTVAArticleList.gql'
 import useMobileOnlyInfiniteScroll from '@/composables/useMobileOnlyInfiniteScroll'
 
@@ -9,7 +8,6 @@ import useMobileOnlyInfiniteScroll from '@/composables/useMobileOnlyInfiniteScro
 const { $graphql } = useNuxtApp()
 
 const route = useRoute()
-// const router = useRouter()
 
 const { data, error } = await useAsyncData('article-list', async () => {
   const data = await $graphql.default.request(FTVAArticleList)
@@ -23,7 +21,6 @@ if (error.value) {
 }
 
 if (!data.value.entry) {
-  // console.log('no data')
   throw createError({
     statusCode: 404,
     statusMessage: 'Page Not Found',
@@ -81,28 +78,17 @@ const articleFetchFunction = async (page) => {
   return results
 }
 const onResults = (results) => {
-  console.log('onResults called with:', results)
-  console.log('Current page:', currentPage.value, 'Is mobile:', isMobile.value)
-
   if (results && results.hits && results?.hits?.hits?.length > 0) {
     const newArticles = results.hits.hits || []
     const calculatedTotalPages = Math.ceil(results.hits.total.value / documentsPerPage)
-
-    console.log('Total hits:', results.hits.total.value, 'Documents per page:', documentsPerPage, 'Calculated total pages:', calculatedTotalPages)
 
     if (isMobile.value) {
       totalPages.value = 0
       mobileItemList.value.push(...newArticles)
       hasMore.value = currentPage.value < calculatedTotalPages
-      console.log('Mobile: hasMore set to:', hasMore.value)
     } else {
-      console.log('Desktop: setting totalPages to:', calculatedTotalPages)
       desktopItemList.value = newArticles
       totalPages.value = calculatedTotalPages
-      hasMore.value = false
-      console.log('Desktop: hasMore set to:', hasMore.value)
-
-      // TO DO CHECK if we need to set value for hasMore to false here
     }
   } else {
     console.log('No results found, setting totalPages to 0 and hasMore to false')
@@ -121,7 +107,7 @@ const savedScrollPosition = ref(0)
 // Save scroll position before route update
 onBeforeRouteUpdate((to, from) => {
   if (to.query.page !== from.query.page) {
-    console.log('Saving scroll position before navigation:', window.scrollY)
+    // console.log('Saving scroll position before navigation:', window.scrollY)
     savedScrollPosition.value = window.scrollY
   }
 })
@@ -129,20 +115,16 @@ onBeforeRouteUpdate((to, from) => {
 watch(
   () => route.query,
   (newVal, oldVal) => {
-    console.log('In watch route query', newVal, oldVal)
-    console.log('Current page:', currentPage.value, 'New page:', route.query.page ? parseInt(route.query.page) : 1)
-    console.log('Is mobile:', isMobile.value)
+    // console.log('In watch route query', newVal, oldVal)
+    // console.log('Current page:', currentPage.value, 'New page:', route.query.page ? parseInt(route.query.page) : 1)
+    // console.log('Is mobile:', isMobile.value)
 
     isLoading.value = false
 
     currentPage.value = route.query.page ? parseInt(route.query.page) : 1
 
     // Clear the lists when route changes
-    if (isMobile.value) {
-      mobileItemList.value = []
-    } else {
-      desktopItemList.value = []
-    }
+    isMobile.value ? mobileItemList.value = [] : desktopItemList.value = []
 
     hasMore.value = true
     searchES()

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -98,6 +98,10 @@ const onResults = (results) => {
       console.log('Desktop: setting totalPages to:', calculatedTotalPages)
       desktopItemList.value = newArticles
       totalPages.value = calculatedTotalPages
+      hasMore.value = currentPage.value < calculatedTotalPages
+      console.log('Desktop: hasMore set to:', hasMore.value)
+
+      // TO DO CHECK if we need to set value for hasMore to false here
     }
   } else {
     console.log('No results found, setting totalPages to 0 and hasMore to false')

--- a/pages/collections/motion-picture/index.vue
+++ b/pages/collections/motion-picture/index.vue
@@ -5,6 +5,7 @@ import _get from 'lodash/get'
 
 import FTVACollectionTypeListing from '../gql/queries/FTVACollectionTypeListing.gql'
 import useMobileOnlyInfiniteScroll from '@/composables/useMobileOnlyInfiniteScroll'
+import usePaginationScroll from '@/composables/usePaginationScroll.ts'
 
 const { $graphql } = useNuxtApp()
 
@@ -127,6 +128,9 @@ const onResults = (results) => {
 // INFINITE SCROLL
 const { isLoading, isMobile, hasMore, desktopItemList, mobileItemList, totalPages, currentPage, currentList, scrollElem, searchES } = useMobileOnlyInfiniteScroll(collectionFetchFunction, onResults)
 
+// PAGINATION SCROLL HANDLING
+const { restoreScrollPosition } = usePaginationScroll('collection-section-title')
+
 function browseBySelectedLetter(letter) {
   desktopItemList.value = []
   mobileItemList.value = []
@@ -166,6 +170,9 @@ watch(() => route.query,
     }
 
     searchES()
+
+    // Restore scroll position
+    restoreScrollPosition()
   }, { deep: true, immediate: true }
 )
 
@@ -237,6 +244,7 @@ useHead({
     </SectionWrapper>
 
     <SectionWrapper
+      id="collection-section-title"
       ref="scrollElem"
       :section-title="pageTitle"
       class="section-wrapper__page-header"

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -4,6 +4,7 @@ import SvgGlyphX from 'ucla-library-design-tokens/assets/svgs/icon-ftva-xtag.svg
 import parseFilters from '@/utils/parseFilters'
 import parseImage from '@/utils/parseImage'
 import useMobileOnlyInfiniteScroll from '@/composables/useMobileOnlyInfiniteScroll'
+import usePaginationScroll from '@/composables/usePaginationScroll'
 
 const route = useRoute()
 const documentsPerPage = 10
@@ -152,6 +153,9 @@ const onResults = (results) => {
 // mostly provided by 'useMobileOnlyInfiniteScroll' composable
 const { isLoading, isMobile, hasMore, desktopPage, desktopItemList, mobileItemList, totalPages, currentPage, currentList, scrollElem, reset, searchES } = useMobileOnlyInfiniteScroll(searchResultsFetchFunction, onResults)
 
+// PAGINATION SCROLL HANDLING
+const { restoreScrollPosition } = usePaginationScroll('search-section-title')
+
 // SORT SETUP - uses static data
 const sortDropdownData = {
   options: [
@@ -192,6 +196,9 @@ watch(
       // console.log('orderBy updated', orderBy.value)
     }
     searchES()
+
+    // Restore scroll position
+    restoreScrollPosition()
   }, { deep: true, immediate: true }
 )
 
@@ -402,6 +409,7 @@ function applyChangesToSearch() {
 <template>
   <main class="page page-detail page-detail--paleblue search-page">
     <SectionWrapper
+      id="search-section-title"
       ref="scrollElem"
       theme="paleblue"
       class="one-column"

--- a/pages/series/index.vue
+++ b/pages/series/index.vue
@@ -6,6 +6,7 @@ import _get from 'lodash/get'
 import FTVAEventSeriesList from '../gql/queries/FTVAEventSeriesList.gql'
 
 import useMobileOnlyInfiniteScroll from '@/composables/useMobileOnlyInfiniteScroll'
+import usePaginationScroll from '@/composables/usePaginationScroll.ts'
 
 const { $graphql } = useNuxtApp()
 
@@ -141,6 +142,9 @@ const onResults = (results) => {
 // INFINITE SCROLL
 const { isLoading, isMobile, hasMore, desktopItemList, mobileItemList, totalPages, currentPage, currentList, scrollElem, searchES } = useMobileOnlyInfiniteScroll(seriesFetchFunction, onResults)
 
+// PAGINATION SCROLL HANDLING
+const { restoreScrollPosition } = usePaginationScroll('series-section-title')
+
 watch(() => route.query,
   (newVal, oldVal) => {
     isLoading.value = false
@@ -149,6 +153,9 @@ watch(() => route.query,
     hasMore.value = true
 
     searchES()
+
+    // Restore scroll position
+    restoreScrollPosition()
   }, { deep: true, immediate: true }
 )
 
@@ -179,6 +186,7 @@ const parsedEventSeries = computed(() => {
   <div class="page page-event-series">
     <div class="full-width">
       <SectionWrapper
+        id="series-section-title"
         ref="scrollElem"
         class="header"
         :section-title="heading.titleGeneral"


### PR DESCRIPTION
Connected to [APPS-3212](https://jira.library.ucla.edu/browse/APPS-3212)

**Composable Created:** composables/usePaginationScroll.ts

**Page/Pages Created/updated:** 
/blog/index.vue 
/components/ListOfItemsCollection.vue
/search.vue
/series/index.vue
/collections/motion-picture/index.vue

**Notes:**

🐞 What was happening:  when clicking a pagination link on the last page of pagination, the website was attempting to return to the same position on the page. However, since there are fewer items on the last page, it was jumping all the way to the bottom of the page instead.  see the old behavior here for comparison  https://deploy-preview-185--test-ftva.netlify.app/blog/  

🛠️ What we changed: When a pagination button is clicked, the page will jump to the top of the section instead.  

**Time Report:**

This took me 30ish hours to build this. This included time to diagnose the issue, create the first fix, review with UX, modify the fix, refactor the solution into a composable, and apply the composable on the pages with SectionPagination

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   [X] I completed any required mobile breakpoint styling
-   [X] I completed any required hover state styling
-   [X] I included a working spec file
-   [X] I added notes above about how long it took to build this component
-   [X] UX has reviewed this PR
-   ~~[ ] I assigned this PR to someone to review~~


[APPS-3212]: https://uclalibrary.atlassian.net/browse/APPS-3212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ