### PR TITLE
fix: APPS-3380 working template title for each page

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -27,6 +27,28 @@ onMounted(async () => {
     await $layoutData()
   }
 })
+
+// set title
+useHead({
+  titleTemplate: (titleChunk) => {
+    return titleChunk === 'Homepage'
+      ? 'UCLA Film & Television Archive'
+      : `${titleChunk || 'Error'} | UCLA Film & Television Archive`
+  },
+  htmlAttrs: {
+    lang: 'en',
+  },
+  meta: [
+    { charset: 'utf-8' },
+    {
+      name: 'viewport',
+      content: 'width=device-width, initial-scale=1.0, minimum-scale=1.0',
+    },
+  ],
+  link: [
+    { rel: 'icon', type: 'image/svg', href: '/icon-ucla-favicon.svg' },
+  ],
+})
 </script>
 
 <template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -125,24 +125,6 @@ export default defineNuxtConfig({
       name: 'fade',
       mode: 'out-in',
     },
-    head: {
-      titleTemplate: (titleChunk: string) => {
-        // If undefined or blank then we don't need the pipe and space
-        return titleChunk === 'Homepage' ? 'UCLA Film & Television Archive' : `${titleChunk || 'Error'}` + ' | UCLA Film & Television Archive'
-      },
-      htmlAttrs: {
-        lang: 'en',
-      },
-      meta: [
-        { charset: 'utf-8' },
-        {
-          name: 'viewport',
-          content:
-            'width=device-width, initial-scale=1.0, minimum-scale=1.0',
-        },
-      ],
-      link: [{ rel: 'icon', type: 'image/svg', href: '/icon-ucla-favicon.svg' }],
-    },
   },
 
   /*


### PR DESCRIPTION
Connected to [APPS-3380](https://jira.library.ucla.edu/browse/APPS-3380)

**Page/Pages Created/updated:** app.vue from

**Notes:**

The template title was previously in nuxt.config.ts. It needed to be moved to app.vue to function. 

**Time Report:**

This took me 2 hours to build.

**Checklist:**

-   [ ] I added github label for semantic versioning
-   [ ] I double checked it looks like the designs
-   [ ] I completed any required mobile breakpoint styling
-   [ ] I completed any required hover state styling
-   [ ] I included a working spec file
-   [ ] I added notes above about how long it took to build this component
-   [ ] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review
