### PR TITLE
chore: APPS-3283 remove collection group

### DIFF
--- a/pages/collections/[collectionSlug]/[slug].vue
+++ b/pages/collections/[collectionSlug]/[slug].vue
@@ -74,7 +74,7 @@ interface Metadata {
   'Episode Title'?: string
   'Episode Season'?: string
   'Episode Number'?: string
-  'Collection Group'?: string[]
+  // 'Collection Group'?: string[]
   Tags?: string[]
   Director?: LinkedIndividual[],
   Year?: string
@@ -91,7 +91,7 @@ const parsedMetadataList = computed((): Metadata => {
     'Episode Title': page.value.episodeTitle,
     'Episode Season': page.value.episodeSeason,
     'Episode Number': page.value.episodeNumber,
-    'Collection Group': getObjectValue(page.value.ftvaCollectionGroup, 'title'),
+    // 'Collection Group': getObjectValue(page.value.ftvaCollectionGroup, 'title'),
     Tags: getObjectValue(page.value.ftvaCollectionTags, 'title'),
     Director: getLinkedIndividual(page.value.director),
     Year: page.value.year,


### PR DESCRIPTION
Connected to [APPS-3283](https://jira.library.ucla.edu/browse/APPS-3283)

**Page/Pages Created/updated:** collections/[collectionSlug]/slug.vue

**Notes:**
I only commented out the collection group lines because Axa specified commenting them out and not deleting them. 

**Time Report:**

This took me 1 hours to build this.

**Photos:** 
Before:
<img width="1260" height="656" alt="Screenshot 2025-08-06 at 12 21 27 PM" src="https://github.com/user-attachments/assets/73c684be-aff8-4de0-9013-769d3ec46758" />

After: 
<img width="1231" height="666" alt="Screenshot 2025-08-06 at 12 21 43 PM" src="https://github.com/user-attachments/assets/34577c94-7381-4427-8e00-762eba60305d" />

**Link:**
https://deploy-preview-190--test-ftva.netlify.app/collections/ktla-newsfilm-collection/senator-john-f-kennedy-gives-press-conference-in-los-angeles/

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I double checked it looks like the designs
-   [x] I completed any required mobile breakpoint styling
-   [x] I completed any required hover state styling
-   [ ] I included a working spec file
-   [x] I added notes above about how long it took to build this component
-   [x] UX has reviewed this PR
-   [x] I assigned this PR to someone to review


[APPS-3283]: https://uclalibrary.atlassian.net/browse/APPS-3283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ