### PR TITLE
feat: APPS-3180 add display summary logic

### DIFF
--- a/gql/queries/FTVACollectionTypeListing.gql
+++ b/gql/queries/FTVACollectionTypeListing.gql
@@ -9,6 +9,7 @@ query FTVACollectionsListing($section: [String!]) {
     postDate
     title: titleGeneral
     summary
+    displaySummary
     sectionHeader {
       sectionTitle
       sectionSummary

--- a/gql/queries/FTVAEventSeriesList.gql
+++ b/gql/queries/FTVAEventSeriesList.gql
@@ -8,6 +8,7 @@ query FTVAEventSeriesList {
     postDate
     titleGeneral
     summary
+    displaySummary
   }
   entries(section: ["ftvaEventSeries"], orderBy: "postDate DESC") {
     id

--- a/pages/archive-research-study-center/index.vue
+++ b/pages/archive-research-study-center/index.vue
@@ -62,11 +62,6 @@ watch(data, (newVal, oldVal) => {
   page.value = _get(newVal, 'entry', {})
 })
 
-// PAGE SUMMARY
-const showPageSummary = computed(() => {
-  return page.value?.summary && page.value?.displaySummary === 'yes'
-})
-
 const pageClass = computed(() => {
   return ['page', 'page-detail', 'page-detail--paleblue', route.path.slice(1)]
 })
@@ -144,9 +139,6 @@ useHead({
       class="header"
       data-test=""
     >
-      <template v-if="showPageSummary">
-        <RichText :rich-text-content="page.summary" />
-      </template>
     </SectionWrapper>
 
     <FlexibleBlocks

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -54,7 +54,6 @@ if (data.value.entry && import.meta.prerender) {
 // DATA
 const page = ref(_get(data.value, 'entry', {}))
 const pageTitle = page.value.title
-const pageSummary = page.value.summary
 const featuredArticles = page.value.ftvaFeaturedArticles
 
 // PREVIEW WATCHER FOR CRAFT CONTENT
@@ -62,7 +61,6 @@ watch(data, (newVal, oldVal) => {
   // console.log('In watch preview enabled, newVal, oldVal', newVal, oldVal)
   page.value = _get(newVal, 'entry', {})
   pageTitle.value = page.value.title
-  pageSummary.value = page.value.summary
   featuredArticles.value = page.value.ftvaFeaturedArticles
 })
 
@@ -201,7 +199,10 @@ useHead({
       data-test="blog-page-title"
     >
       <template v-if="showPageSummary">
-        <RichText :rich-text-content="pageSummary" />
+        <RichText
+          :rich-text-content="page.summary"
+          data-test="page-description"
+        />
       </template>
     </SectionWrapper>
 

--- a/pages/collections/la-rebellion/filmmakers/index.vue
+++ b/pages/collections/la-rebellion/filmmakers/index.vue
@@ -60,6 +60,11 @@ watch(data, (newVal, oldVal) => {
   page.value = _get(newVal, 'entry', {})
 })
 
+// PAGE SUMMARY
+const showPageSummary = computed(() => {
+  return page.value?.summary && page.value?.displaySummary === 'yes'
+})
+
 useHead({
   title: page.value ? page.value.title : '... loading',
   meta: [
@@ -184,7 +189,7 @@ const pageClasses = computed(() => {
         ref="scrollElem"
         class="header"
         :section-title="page.title"
-        :section-summary="page.summary"
+        :section-summary="showPageSummary ? page.summary : ''"
         theme="paleblue"
         data-test="page-heading"
       >

--- a/pages/collections/motion-picture/index.vue
+++ b/pages/collections/motion-picture/index.vue
@@ -72,7 +72,6 @@ if (data.value.entry && import.meta.prerender) {
 // DATA
 const page = ref(_get(data.value, 'entry', {}))
 const pageTitle = page.value.title
-const pageSummary = page.value.summary
 const generalContentPagesSection = page.value.sectionHeader[0]
 const generalContentPages = page.value.associatedGeneralContentPagesFtva
 
@@ -80,9 +79,13 @@ const generalContentPages = page.value.associatedGeneralContentPagesFtva
 watch(data, (newVal, oldVal) => {
   page.value = _get(newVal, 'entry', {})
   pageTitle.value = page.value.title
-  pageSummary.value = page.value.summary
   generalContentPagesSection.value = page.value.sectionHeader[0]
   generalContentPages.value = page.value.associatedGeneralContentPagesFtva
+})
+
+// PAGE SUMMARY
+const showPageSummary = computed(() => {
+  return page.value?.summary && page.value?.displaySummary === 'yes'
 })
 
 // ELASTIC SEARCH
@@ -250,7 +253,12 @@ useHead({
         theme="paleblue"
         data-test="page-title"
       >
-        <RichText :rich-text-content="pageSummary" />
+        <template v-if="showPageSummary">
+          <RichText
+            :rich-text-content="page.summary"
+            data-test="page-description"
+          />
+        </template>
       </SectionWrapper>
 
       <SectionWrapper

--- a/pages/series/index.vue
+++ b/pages/series/index.vue
@@ -70,6 +70,11 @@ watch(data, (newVal, oldVal) => {
   heading.value = _get(newVal, 'entry', {})
 })
 
+// PAGE SUMMARY
+const showPageSummary = computed(() => {
+  return heading.value?.summary && heading.value?.displaySummary === 'yes'
+})
+
 // "STATE"
 const route = useRoute()
 const currentView = computed(() => route.query.view || 'current') // Tracks 'current' or 'past'
@@ -190,7 +195,7 @@ const parsedEventSeries = computed(() => {
         ref="scrollElem"
         class="header"
         :section-title="heading.titleGeneral"
-        :section-summary="heading.summary"
+        :section-summary="showPageSummary ? heading.summary : ''"
         theme="paleblue"
       />
 


### PR DESCRIPTION
Connected to [APPS-3180](https://jira.library.ucla.edu/browse/APPS-3180)

**Page/Pages Created/updated:** 

- archive-research-study-center/index.vue
- blog/index.vue
- collections/la-rebellion/filmmakers/index.vue
- collections/motion-picture/index.vue
- series/index.vue

**Notes:**
This adds the DisplaySummary logic to the page.summary display. The logic has been removed from ARSC page because it is not using the page summary to render the information. None of the UX/UI has been changed as a result of these additions. To test this, go into craft and toggle the `Display Summary` field on the single pages. When it is `no` the summary will not appear for each of these pages, if it is `yes` it will appear. 

**Links:**
https://deploy-preview-193--test-ftva.netlify.app/collections/motion-picture
https://deploy-preview-193--test-ftva.netlify.app/collections/watch-listen-online
https://deploy-preview-193--test-ftva.netlify.app/collections/television
https://deploy-preview-193--test-ftva.netlify.app/collections/la-rebellion/filmmakers/
https://deploy-preview-193--test-ftva.netlify.app/series/

**Time Report:**

This took me 12 hours to build this.

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I double checked it looks like the designs
-   [x] I completed any required mobile breakpoint styling
-   [x] I completed any required hover state styling
-   [ ] I included a working spec file
-   [x] I added notes above about how long it took to build this component
-   [ ] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-3180]: https://uclalibrary.atlassian.net/browse/APPS-3180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ