### PR TITLE
feat: ensure all listings fallback to imageCarousel where possible

### DIFF
--- a/components/BasicCollection.vue
+++ b/components/BasicCollection.vue
@@ -123,7 +123,7 @@ const parsedRelatedCollections = computed(() => {
       category: 'collection',
       // Remove image tags inside byline rich text
       bylineOne: item.richText.replace(/<img.*?>/ig, ''),
-      image: item.ftvaImage && item.ftvaImage.length > 0 ? item.ftvaImage[0] : null,
+      image: parseImage(item)
     }
   })
   return relatedCollections

--- a/components/ListOfItemsCollection.vue
+++ b/components/ListOfItemsCollection.vue
@@ -89,7 +89,7 @@ const { restoreScrollPosition } = usePaginationScroll('collection-items-section-
 const parsedCollectionResults = computed(() => {
   if (currentList.value.length === 0) return []
   return currentList.value.map((obj) => {
-    const objImage = obj._source.ftvaImage.length ? obj._source.ftvaImage[0] : null
+    const objImage = parseImage(obj)
     return {
       ...obj._source,
       title: obj._source.title,

--- a/gql/queries/FTVAArticleDetail.gql
+++ b/gql/queries/FTVAArticleDetail.gql
@@ -60,6 +60,9 @@ query FTVAArticleDetail($slug: [String!]) {
         }
       }
     }
+    image: ftvaImage {
+      ...Image
+    }
     postDate @formatDateTime(format: "mm d, Y", timezone: "America/Los_Angeles")
   }
 }

--- a/gql/queries/FTVAArticleList.gql
+++ b/gql/queries/FTVAArticleList.gql
@@ -21,6 +21,15 @@ query FTVAArticleList($slug: [String!]) {
       image: ftvaImage {
         ...Image
       }
+
+      imageCarousel {
+        ... on imageCarousel_imageCarousel_BlockType {
+          image {
+            ...Image
+          }
+          creditText
+        }
+      }
     }
   }
 }

--- a/gql/queries/FTVACollectionDetail.gql
+++ b/gql/queries/FTVACollectionDetail.gql
@@ -41,6 +41,14 @@ query FTVACollectionDetail($slug: [String!]) {
       ftvaImage {
         ...Image
       }
+      imageCarousel {
+        ... on imageCarousel_imageCarousel_BlockType {
+          image {
+            ...Image
+          }
+          creditText
+        }
+      }
       title
       richText
       uri

--- a/gql/queries/FTVACollectionItem.gql
+++ b/gql/queries/FTVACollectionItem.gql
@@ -15,6 +15,14 @@ query FTVACollectionItem($collectionSlug: [String!], $slug: [String!]) {
     ftvaImage {
       ...Image
     }
+    imageCarousel {
+      ... on imageCarousel_imageCarousel_BlockType {
+        image {
+          ...Image
+        }
+        creditText
+      }
+    }
     videoEmbed
     richText
     externalResourceUrl
@@ -67,6 +75,14 @@ query FTVACollectionItem($collectionSlug: [String!], $slug: [String!]) {
     uri
     ftvaImage {
       ...Image
+    }
+    imageCarousel {
+      ... on imageCarousel_imageCarousel_BlockType {
+        image {
+          ...Image
+        }
+        creditText
+      }
     }
      videoEmbed
   }

--- a/gql/queries/FTVACollectionList.gql
+++ b/gql/queries/FTVACollectionList.gql
@@ -63,6 +63,14 @@ query FTVACollectionList {
             image: ftvaImage {
               ...Image
             }
+            imageCarousel {
+              ... on imageCarousel_imageCarousel_BlockType {
+                image {
+                  ...Image
+                }
+                creditText
+              }
+            }
           }
         }
       }
@@ -76,6 +84,14 @@ query FTVACollectionList {
             uri
             image: ftvaImage {
               ...Image
+            }
+            imageCarousel {
+              ... on imageCarousel_imageCarousel_BlockType {
+                image {
+                  ...Image
+                }
+                creditText
+              }
             }
           }
         }

--- a/gql/queries/FTVAEventSeriesDetail.gql
+++ b/gql/queries/FTVAEventSeriesDetail.gql
@@ -83,6 +83,13 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
       image: ftvaImage {
         ...Image
       }
+      imageCarousel {
+        ... on imageCarousel_imageCarousel_BlockType {
+          image {
+            ...Image
+          }
+        }
+      }
       ftvaScreeningFormatFilters {
         id
         title
@@ -104,6 +111,13 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
     image: ftvaImage {
       ...Image
     }
+    imageCarousel {
+      ... on imageCarousel_imageCarousel_BlockType {
+        image {
+          ...Image
+        }
+      }
+    }
     ftvaScreeningFormatFilters {
       id
       title
@@ -123,6 +137,13 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
     ftvaImage {
       ...Image
     }
+    imageCarousel {
+        ... on imageCarousel_imageCarousel_BlockType {
+          image {
+            ...Image
+          }
+        }
+    }
   }
   otherSeriesUpcoming: entries(section: "ftvaEventSeries", limit: 3, endDate: ">=now", orderBy: "startDate ASC") {
     uri
@@ -133,6 +154,13 @@ query FTVAEventSeriesDetail ($slug: [String!]) {
     ongoing
     ftvaImage {
       ...Image
+    }
+    imageCarousel {
+        ... on imageCarousel_imageCarousel_BlockType {
+          image {
+            ...Image
+          }
+        }
     }
   }
 }

--- a/gql/queries/FTVAHomepage.gql
+++ b/gql/queries/FTVAHomepage.gql
@@ -49,6 +49,13 @@ query FTVAHomepage {
           ftvaImage {
             ...Image
           }
+          imageCarousel {
+            ... on imageCarousel_imageCarousel_BlockType {
+              image {
+                ...Image
+              }
+            }
+          }
         }
         }
         }
@@ -106,6 +113,14 @@ query FTVAHomepage {
             ftvaHomepageDescription
             ftvaImage {
               ...Image
+            }
+            imageCarousel {
+              ... on imageCarousel_imageCarousel_BlockType {
+                image {
+                  ...Image
+                }
+                altText
+              }
             }
           }
         }

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -102,7 +102,7 @@ const parsedRecentPosts = computed(() => {
   const recentPostsWImage = ftvaRecentPosts.value.map((item, index) => {
     return {
       ...item,
-      image: item.imageCarousel && item.imageCarousel.length > 0 ? item.imageCarousel[0].image[0] : null,
+      image: parseImage(item)
     }
   })
   return recentPostsWImage.filter(item => !item.to.includes(route.params.slug)).slice(0, 3)

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -138,9 +138,8 @@ const parsedFeaturedArticles = computed(() => {
 
   return featuredArticles.map((obj) => {
     const parsedTitle = parseRichTextTitle(obj)
-
     return {
-      image: obj.image[0],
+      image: parseImage(obj),
       to: `/${obj.uri}`,
       title: parsedTitle,
       category: parseArticleCategories(obj.articleCategories),

--- a/pages/collections/[collectionSlug]/[slug].vue
+++ b/pages/collections/[collectionSlug]/[slug].vue
@@ -182,7 +182,7 @@ const parsedRelatedContent = computed(() => {
 
   return filteredRelatedContent.slice(0, 3).map((obj) => {
     return {
-      image: obj.ftvaImage[0],
+      image: parseImage(obj),
       title: obj.title,
       to: obj.slug,
       videoEmbed: obj.videoEmbed

--- a/pages/collections/index.vue
+++ b/pages/collections/index.vue
@@ -71,7 +71,7 @@ const parsedCollections = computed(() => {
       return {
         ...item,
         to: item.uri,
-        image: item.imageCarousel[0]?.image[0]
+        image: parseImage(item)
       }
     })
 
@@ -89,7 +89,7 @@ const parsedResources = computed(() => {
     return {
       title: obj.title,
       to: `/${obj.uri}`,
-      image: obj.image[0]
+      image: parseImage(obj)
     }
   })
 })
@@ -101,7 +101,7 @@ const parsedAboutCollections = computed(() => {
     return {
       title: obj.title,
       to: `/${obj.uri}`,
-      image: obj.image[0]
+      image: parseImage(obj)
     }
   })
 })

--- a/pages/collections/la-rebellion/index.vue
+++ b/pages/collections/la-rebellion/index.vue
@@ -70,7 +70,7 @@ const parsedAdditionalResources = computed(() => {
     return {
       title: obj.title,
       to: `/${obj.uri}`,
-      image: obj.ftvaImage[0]
+      image: parseImage(obj)
     }
   })
 })

--- a/pages/collections/motion-picture/index.vue
+++ b/pages/collections/motion-picture/index.vue
@@ -190,7 +190,7 @@ const parsedGeneralContentPages = computed(() => {
     return {
       title: obj.title,
       to: `/${obj.uri}`,
-      image: obj.ftvaImage[0]
+      image: parseImage(obj)
     }
   })
 })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -95,7 +95,7 @@ const parsedNowShowing = computed(() => {
     return {
       ...item,
       to: `/${item.uri}`,
-      image: item.ftvaImage && item.ftvaImage.length > 0 ? item.ftvaImage[0] : null,
+      image: parseImage(item),
       startDate: item.startDateWithTime || item.startDate,
     }
   })
@@ -110,7 +110,7 @@ const parsedQuickLinks = computed(() => {
       title: item.titleGeneral,
       to: item.urlLink,
       text: item.description,
-      image: item.image[0],
+      image: item.image[0], // quicklinks are not using parseImage, they have an image field that overrides the image / carousel field in parseImage
     }
   })
 })
@@ -126,7 +126,7 @@ const parsedArchiveBlogs = computed(() => {
     blogTitle: obj.featuredArticles[0]?.title,
     blogUri: obj.featuredArticles[0].uri,
     blogSummary: obj.featuredArticles[0].ftvaHomepageDescription,
-    image: obj.featuredArticles[0].ftvaImage
+    image: [parseImage(obj.featuredArticles[0])] // parseImage results must be wrapped in an array for BlockMediaWithText component
   }
 })
 
@@ -138,7 +138,7 @@ const parsedFeaturedCollections = computed(() => {
     return {
       title: item.title,
       to: item.uri,
-      image: item.imageCarousel && item.imageCarousel.length > 0 ? item.imageCarousel[0].image[0] : null,
+      image: parseImage(item)
     }
   })
 

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -104,7 +104,7 @@ const parsedUpcomingEvents = computed(() => {
       ...item,
       tagLabels: parsedTagLabels,
       to: `/${item.to}`,
-      image: item.image && item.image.length > 0 ? item.image[0] : null
+      image: parseImage(item)
     }
   })
 })
@@ -122,7 +122,7 @@ const parsedPastEvents = computed(() => {
       ...item,
       tagLabels: parsedTagLabels,
       to: `/${item.to}`,
-      image: item.image && item.image.length > 0 ? item.image[0] : null
+      image: parseImage(item) // item.image && item.image.length > 0 ? item.image[0] : null // parseImage
     }
   })
 })
@@ -158,7 +158,7 @@ const parsedOtherSeries = computed(() => {
       endDate: item.endDate ? item.endDate : null,
       ongoing: item.ongoing,
       sectionHandle: item.sectionHandle, // 'ftvaEventSeries'
-      image: item.ftvaImage && item.ftvaImage.length > 0 ? item.ftvaImage[0] : null,
+      image: parseImage(item) // item.ftvaImage && item.ftvaImage.length > 0 ? item.ftvaImage[0] : null, // parseImage
     }
   })
   return otherSeries

--- a/utils/parseImage.js
+++ b/utils/parseImage.js
@@ -1,7 +1,13 @@
 export default function parseImage(obj) {
-  const listingImage = obj._source.image || obj._source.ftvaImage
-
-  const carouselImage = obj._source.imageCarousel
+  let listingImage
+  let carouselImage
+  if (obj._source) {
+    listingImage = obj._source.image || obj._source.ftvaImage
+    carouselImage = obj._source.imageCarousel || obj.imageCarousel
+  } else {
+    listingImage = obj.image || obj.ftvaImage
+    carouselImage = obj.imageCarousel
+  }
 
   if (listingImage !== undefined && listingImage.length === 1) {
     // Use Listing Image


### PR DESCRIPTION
Connected to [APPS-3203](https://jira.library.ucla.edu/browse/APPS-3203)

**Notes:**

- [X] Updated the parseImage utility to work for objects with the structure 'obj' or 'obj._source'
- [X] Checked each page for images being parsed as part of a listing or section
- [X] Tested each case using `test-craft` data 
- [X] Added imageCarousel data to some gql files to ensure data is available as a fallback
- [X] Updated image logic to parseImage logic in many templates
- [X] Added comments where there are edge cases to denote that

**Time Report:**

This took me 25ish hours to build this. Mostly crawling around the site to find cases, logging them all, and then testing each one. 

**Checklist:**

-   [X] I added github label for semantic versioning
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   [X] I added notes above about how long it took to build this component
-   ~~[ ] UX has reviewed this PR~~
-   [ ] I assigned this PR to someone to review
