### PR TITLE
fix: APPS-3398 collections carousel images routes to correct url

### DIFF
--- a/pages/collections/index.vue
+++ b/pages/collections/index.vue
@@ -71,7 +71,7 @@ const parsedCollections = computed(() => {
       return {
         ...item,
         to: item.uri.startsWith('/') ? item.uri : `/${item.uri}`,
-        image: item.imageCarousel[0]?.image[0]
+        image: parseImage(item)
       }
     })
 
@@ -91,7 +91,7 @@ const parsedResources = computed(() => {
       to: obj.uri
         ? `/${obj.uri.replace(/^\/?ftva\//i, '')}` // remove leading "ftva/" if present
         : '/',
-      image: obj.image[0]
+      image: parseImage(obj)
     }
   })
 })
@@ -105,7 +105,7 @@ const parsedAboutCollections = computed(() => {
       to: obj.uri
         ? `/${obj.uri.replace(/^\/?ftva\//i, '')}` // remove leading "ftva/" if present
         : '/',
-      image: obj.image[0]
+      image: parseImage(obj)
     }
   })
 })

--- a/pages/collections/motion-picture/index.vue
+++ b/pages/collections/motion-picture/index.vue
@@ -195,7 +195,7 @@ const parsedGeneralContentPages = computed(() => {
     return {
       title: obj.title,
       to: obj.uri.startsWith('/') ? obj.uri : `/${obj.uri}`,
-      image: obj.ftvaImage[0]
+      image: parseImage(obj)
     }
   })
 })


### PR DESCRIPTION
Connected to [APPS-3398](https://jira.library.ucla.edu/browse/APPS-3398)

**Page/Pages Created/updated:** collections/index.vue and collections/motion-picture/index.vue

**Notes:**

The changes made to make sure that the url appears as `collections/[CollectionName]` instead of `collections/collections/[CollectionName]` when navigating from images in the carousel on the Explore Collections pages to the specific collections. This includes making sure that the routed url is normalized. This means that only one `/` will ever exist when a url is being appended.  It also removes `ftva` from the URLs under `About Our Collections` 
**Time Report:**

This took me 3 hours to build this.

**Photos:**
Before: 
<img width="1257" height="544" alt="Screenshot 2025-08-21 at 11 54 39 AM" src="https://github.com/user-attachments/assets/62f6f47d-7ec5-4e00-8fc0-2ed7977d4ac5" />
<img width="1253" height="520" alt="Screenshot 2025-08-27 at 10 09 08 AM" src="https://github.com/user-attachments/assets/ab30fafc-c719-45f6-b94a-bf313cf3afa1" />

After:
<img width="1265" height="723" alt="Screenshot 2025-08-21 at 11 56 08 AM" src="https://github.com/user-attachments/assets/002aefc3-9436-4362-9e51-653e55b55349" />
<img width="1255" height="434" alt="Screenshot 2025-08-27 at 10 09 19 AM" src="https://github.com/user-attachments/assets/9dd7add6-c5cd-47c6-9d92-5a69580efb6f" />

**Links:**
https://deploy-preview-196--test-ftva.netlify.app/collections/native-american-american-indian-and-first-nations-film-and-television/

https://deploy-preview-196--test-ftva.netlify.app/daffodil-days/

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I double checked it looks like the designs
-   [x] I completed any required mobile breakpoint styling
-   [x] I completed any required hover state styling
-   [ ] I included a working spec file
-   [x] I added notes above about how long it took to build this component
-   [ ] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-3398]: https://uclalibrary.atlassian.net/browse/APPS-3398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ