### PR TITLE
fix: APPS-3402 motion-picture collection page will not load from search results link

### DIFF
--- a/pages/archive-research-study-center/index.vue
+++ b/pages/archive-research-study-center/index.vue
@@ -11,7 +11,9 @@ const route = useRoute()
 // routes this page supports:
 const routeNameToSectionMap = {
   '/archive-research-study-center': 'ftvaArchiveResearchAndStudyCenter',
-  '/instructional-media-collections-services': 'ftvaInstructionalMediaCollectionsAndServices'
+  '/instructional-media-collections-services': 'ftvaInstructionalMediaCollectionsAndServices',
+  '/archive-research-study-center/': 'ftvaArchiveResearchAndStudyCenter',
+  '/instructional-media-collections-services/': 'ftvaInstructionalMediaCollectionsAndServices'
 }
 const { data, error } = await useAsyncData(route.path, async () => {
   // lookup section based on routeNameToSectionMap

--- a/pages/collections/la-rebellion/filmography/index.vue
+++ b/pages/collections/la-rebellion/filmography/index.vue
@@ -14,7 +14,9 @@ const route = useRoute()
 // routes this template/page supports:
 const routeNameToSectionMap = {
   '/collections/la-rebellion/filmography': 'ftvaCollectionListingLARebellion',
-  '/collections/in-the-life/filmography': 'ftvaCollectionListingInTheLife'
+  '/collections/in-the-life/filmography': 'ftvaCollectionListingInTheLife',
+  '/collections/la-rebellion/filmography/': 'ftvaCollectionListingLARebellion',
+  '/collections/in-the-life/filmography/': 'ftvaCollectionListingInTheLife'
 }
 
 const { data, error } = await useAsyncData(`${route.path}-filmography`, async () => {

--- a/pages/collections/motion-picture/index.vue
+++ b/pages/collections/motion-picture/index.vue
@@ -12,13 +12,25 @@ const route = useRoute()
 
 // routes this page template supports:
 const routeNameToSectionMap = {
+  '/collections/motion-picture/': {
+    sectionName: 'ftvaListingMotionPictureCollections',
+    collection: 'motionPicture'
+  },
   '/collections/motion-picture': {
     sectionName: 'ftvaListingMotionPictureCollections',
     collection: 'motionPicture'
   },
+  '/collections/television/': {
+    sectionName: 'ftvaListingTelevisionCollections',
+    collection: 'television'
+  },
   '/collections/television': {
     sectionName: 'ftvaListingTelevisionCollections',
     collection: 'television'
+  },
+  '/collections/watch-listen-online/': {
+    sectionName: 'ftvaListingWatchAndListenOnline',
+    collection: 'watchAndListenOnline'
   },
   '/collections/watch-listen-online': {
     sectionName: 'ftvaListingWatchAndListenOnline',


### PR DESCRIPTION
Connected to [APPS-3402](https://jira.library.ucla.edu/browse/APPS-3402)

**Page/Pages Created/updated:** /collections/motion-picture/index.vue from #APPS-3402

**Notes:**

The issue seems to be with trailing '/' 's in the urls once deployed. This caused the `routeNameToSectionMap` object to fail when the urls didn't match (`/collections/motion-picture` was failing to match `/collections/motion-picture/`).

Because some urls have the trailing slash and some don't I simply added both routes to the route map. 

I also made the same change to the archive study research center & the filmography route, which used the same pattern.

**Time Report:**

It took me about 6 hours to troubleshoot and fix this issue.

**Checklist:**

-   [X] I added github label for semantic versioning
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   [X] I added notes above about how long it took to build this component
-   ~~[ ] UX has reviewed this PR~~
-   [ ] I assigned this PR to someone to review


[APPS-3402]: https://uclalibrary.atlassian.net/browse/APPS-3402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ