### PR TITLE
fix: wrap problem areas in ClientOnly tags

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -251,29 +251,31 @@ function parseDatesAndTimes(typeHandle, startDate, endDate, startDateWithTime, o
       </div>
 
       <!-- Now Showing -->
-      <SectionWrapper
-        v-if="parsedNowShowing"
-        :section-title="page.ftvaFeaturedEventsSection[0].sectionTitle"
-        class="now-showing-section no-padding"
-        theme="paleblue"
-      >
-        <template #top-right>
-          <nuxt-link to="/events">
-            {{ page.ftvaFeaturedEventsSection[0].seeAllText }} <span style="font-size:1.5em;">
-              &#8250;</span>
-          </nuxt-link>
-        </template>
-        <ScrollWrapper class="homepage-scroll-wrapper">
-          <SectionTeaserCard
-            v-if="parsedNowShowing && parsedNowShowing.length > 0"
-            class="now-showing-items hovered-items"
-            :items="parsedNowShowing"
-            :grid-layout="false"
-            data-test="featured-event-items"
-          />
-        </ScrollWrapper>
-        <DividerWayFinder />
-      </SectionWrapper>
+      <ClientOnly>
+        <SectionWrapper
+          v-if="parsedNowShowing"
+          :section-title="page.ftvaFeaturedEventsSection[0].sectionTitle"
+          class="now-showing-section no-padding"
+          theme="paleblue"
+        >
+          <template #top-right>
+            <nuxt-link to="/events">
+              {{ page.ftvaFeaturedEventsSection[0].seeAllText }} <span style="font-size:1.5em;">
+                &#8250;</span>
+            </nuxt-link>
+          </template>
+          <ScrollWrapper class="homepage-scroll-wrapper">
+            <SectionTeaserCard
+              v-if="parsedNowShowing && parsedNowShowing.length > 0"
+              class="now-showing-items hovered-items"
+              :items="parsedNowShowing"
+              :grid-layout="false"
+              data-test="featured-event-items"
+            />
+          </ScrollWrapper>
+          <DividerWayFinder />
+        </SectionWrapper>
+      </ClientOnly>
 
       <!-- Visit and Learn -->
       <SectionWrapper

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -438,13 +438,14 @@ useHead({
         to="/"
         parent-title="Home"
       />
-      <h3
-        v-if="route.query.q"
-        class="search-title"
-      >
-        Search Results for <span class="search-keywords">"{{ route.query.q }}"</span>
-      </h3>
-
+      <ClientOnly>
+        <h3
+          v-if="route.query.q"
+          class="search-title"
+        >
+          Search Results for <span class="search-keywords">"{{ route.query.q }}"</span>
+        </h3>
+      </ClientOnly>
       <NavSearch />
     </SectionWrapper>
     <div class="two-column">
@@ -486,28 +487,30 @@ useHead({
         </div>
       </div>
       <div class="content">
-        <div
-          v-if="noResultsFound && parsedResults.length === 0"
-          class="no-results"
-        >
-          <h4 class="no-results-title">
-            No results found.
-          </h4>
-          <p class="no-results-text">
-            Looking for a specific collection item? Search the UCLA Film & Television Archive
-            Catalog at
-          </p>
-          <button-link
-            label="UC Library Search"
-            icon-name="svg-arrow-right"
-            to="https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA&tab=Articles_books_more_slot&search_scope=ArticlesBooksMore&lang=en&query=any,contains,"
-          />
-        </div>
+        <ClientOnly>
+          <div
+            v-if="noResultsFound && parsedResults.length === 0"
+            class="no-results"
+          >
+            <h4 class="no-results-title">
+              No results found.
+            </h4>
+            <p class="no-results-text">
+              Looking for a specific collection item? Search the UCLA Film & Television Archive
+              Catalog at
+            </p>
+            <button-link
+              label="UC Library Search"
+              icon-name="svg-arrow-right"
+              to="https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA&tab=Articles_books_more_slot&search_scope=ArticlesBooksMore&lang=en&query=any,contains,"
+            />
+          </div>
+        </ClientOnly>
         <div
           v-show="!noResultsFound
             &&
             totalResults > 0
-          "
+            "
           ref="el"
           class="results"
         >
@@ -531,13 +534,6 @@ useHead({
                     updateGroupNameFilters(newFilterSelection)
                   }"
                 />
-                <!--DropdownSingleSelect
-                  v-show="isMobile"
-                  v-model:selected-filters="selectedGroupNameFilters"
-                  label="Filter Results"
-                  :options="searchFilters.options"
-                  field-name="groupName.keyword"
-                /-->
                 <DropdownSingleSelect
                   v-model:selected-filters="selectedSortFilters"
                   :label="sortDropdownData.label"


### PR DESCRIPTION
Connected to [APPS-3409](https://jira.library.ucla.edu/browse/APPS-3409)

**Page/Pages Created/updated:** {filename}.vue from #{issue number}

**Notes:**

Added ClientOnly tags around problem areas that are rendering with API fetched data or route queries which may not be present. 


**Time Report:**

This took me 2ish hours to recreate this issue and fix it. 

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   [X] I added notes above about how long it took to build this component
-   ~~[ ] UX has reviewed this PR~~
-   [ ] I assigned this PR to someone to review
