### PR TITLE
feat: APPS-3435 add 2 new sort options to filmmakers page

### DIFF
--- a/pages/collections/la-rebellion/filmmakers/index.vue
+++ b/pages/collections/la-rebellion/filmmakers/index.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script lang="ts" setup>
 import { computed } from 'vue'
 
 // HELPERS & UTILS
@@ -13,7 +13,7 @@ const { $graphql } = useNuxtApp()
 const { data, error } = await useAsyncData('la-rebellion-filmmakers', async () => {
   const data = await $graphql.default.request(FTVALARebellionFilmmakersList)
   return data
-})
+}) as { data: Ref<{ entry: any } | null>, error: Ref<any> }
 
 if (error.value) {
   throw createError({
@@ -78,15 +78,18 @@ useHead({
 
 // "STATE"
 const documentsPerPage = 12
-const selectedSortFilters = ref({ sortField: 'asc' })
+const selectedSortFilters = ref({ sortField: 'nameLast.keyword asc' })
 
 const filmmakersFetchFunction = async (page) => {
   const { paginatedFilmmakersQuery } = useFilmmakersListSearch()
+  // parse the sort field
+  const sortOnField = selectedSortFilters.value.sortField?.split(' ')[0]
+  const orderBy = selectedSortFilters.value.sortField?.split(' ')[1]
   const results = await paginatedFilmmakersQuery(
     page,
     documentsPerPage,
-    'title.keyword',
-    selectedSortFilters.value.sortField,
+    sortOnField,
+    orderBy,
     ['*']
   )
   return results
@@ -161,9 +164,12 @@ const parsedFilmmakerListings = computed(() => {
 
 // SORT
 const sortDropdownData = {
+  // note: 'nameLast' and 'title' are fields on the indexed ftvaLARebellionIndividual object that we are sorting on
   options: [
-    { label: 'First Name (A - Z)', value: 'asc' },
-    { label: 'First Name (Z - A)', value: 'desc' },
+    { label: 'Last Name (A - Z)', value: 'nameLast.keyword asc' },
+    { label: 'Last Name (Z - A)', value: 'nameLast.keyword desc' },
+    { label: 'First Name (A - Z)', value: 'title.keyword asc' },
+    { label: 'First Name (Z - A)', value: 'title.keyword desc' },
   ],
   label: 'Sort by',
   fieldName: 'sortField'


### PR DESCRIPTION
Connected to [APPS-3435](https://jira.library.ucla.edu/browse/APPS-3435)

**Page/Pages Created/updated:** /collections/la-rebellion/filmmakers/index.vue

**Notes:**

- [X] Added 2 new options to the sort dropdown which allow sorting on filmmaker last name*
- [X] Added logic to the `filmmakersFetchFunction` to parse out the field to search on from the sortDropDown selected valued rather than always searching by the title field.
- [X] restored typescript in this file

*Caveat: Currently, anyone without a last name will be sorted to the bottom of the list when using last name sorts.  (Like https://test-craft.library.ucla.edu/admin/entries/ftvaLARebellionIndividual/3474661-darin-scott appears out of order, but really has no last name entered in craft). UX is aware of this limitation and has approved it. I believe the intention is that they will use this on production to identify entries that need data re-formatted.

**Time Report:**

This took me 3 hours to build & test this.

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   [X] I completed any required mobile breakpoint styling
-   [X] I completed any required hover state styling
-   [X] I included a working spec file
-   [X] I added notes above about how long it took to build this component
-   [X] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-3435]: https://uclalibrary.atlassian.net/browse/APPS-3435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ