### PR TITLE
fix: APPS-3432 update text in sesarch results call to action

### DIFF
--- a/pages/search.vue
+++ b/pages/search.vue
@@ -589,7 +589,7 @@ useHead({
     >
       <block-call-to-action
         class=""
-        v-bind="{ title: 'Looking for a specific collection item?', text: 'Search the UCLA Film & Television Archive Catalog.', name: 'UC Library Search', to: 'https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA&tab=Articles_books_more_slot&search_scope=ArticlesBooksMore&lang=en&query=any,contains,', isDark: false, svgName: 'svg-call-to-action-question' }"
+        v-bind="{ title: 'Looking for a specific collection item?', text: 'Search the UCLA Film & Television Archive Catalog at UC Library Search', name: 'UC Library Search', to: 'https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA&tab=Articles_books_more_slot&search_scope=ArticlesBooksMore&lang=en&query=any,contains,', isDark: false, svgName: 'svg-call-to-action-question' }"
       />
     </SectionWrapper>
   </main>


### PR DESCRIPTION
Connected to [APPS-3432](https://jira.library.ucla.edu/browse/APPS-3432)

**Page/Pages Created/updated:** search.vue from #{issue number}

**Notes:**
Switch text to new specified text

**Time Report:**

This took me 1 hours to build this.

**Links:**
https://deploy-preview-210--test-ftva.netlify.app/search?q=test

**Photos:** 
Before: 
<img width="1135" height="576" alt="Screenshot 2025-09-17 at 11 29 50 AM" src="https://github.com/user-attachments/assets/b12b4c3d-71d7-40fc-afc4-504120f38980" />
After: 
<img width="826" height="434" alt="Screenshot 2025-09-17 at 11 30 05 AM" src="https://github.com/user-attachments/assets/6c28fb37-8cba-42ed-9155-db9810c742e7" />

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I double checked it looks like the designs
-   [x] I completed any required mobile breakpoint styling
-   [x] I completed any required hover state styling
-   [ ] I included a working spec file
-   [x] I added notes above about how long it took to build this component
-   [x] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-3432]: https://uclalibrary.atlassian.net/browse/APPS-3432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ