### PR TITLE
APPS-3438 fix: hide about the author title when no data

### DIFF
--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -185,7 +185,10 @@ useHead({
           </template>
         </CardMeta>
 
-        <h3 class="about-the-author">
+        <h3
+          v-if="page?.aboutTheAuthor"
+          class="about-the-author"
+        >
           About the Author
         </h3>
 


### PR DESCRIPTION
Connected to [APPS-3438](https://jira.library.ucla.edu/browse/APPS-3438)

**Page/Pages Created/updated:** {filename}.vue from #{issue number}

**Notes:**

Very quick fix, just adding a v-if check for the about the author title text itself like we already had for the content

**Time Report:**

This took me 30ish minutes to build this.

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   [X] I completed any required mobile breakpoint styling
-   [X] I completed any required hover state styling
-   [X] I included a working spec file
-   [X] I added notes above about how long it took to build this component
-   ~~[ ] UX has reviewed this PR~~
-   [ ] I assigned this PR to someone to review
