### PR TITLE
fix: APPS-3428 update URL to UC library search

### DIFF
--- a/pages/search.vue
+++ b/pages/search.vue
@@ -502,7 +502,7 @@ useHead({
             <button-link
               label="UC Library Search"
               icon-name="svg-arrow-right"
-              to="https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA&tab=Articles_books_more_slot&search_scope=ArticlesBooksMore&lang=en&query=any,contains,"
+              to="https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA&mode=advanced"
             />
           </div>
         </ClientOnly>
@@ -510,7 +510,7 @@ useHead({
           v-show="!noResultsFound
             &&
             totalResults > 0
-          "
+            "
           ref="el"
           class="results"
         >
@@ -585,7 +585,7 @@ useHead({
     >
       <block-call-to-action
         class=""
-        v-bind="{ title: 'Looking for a specific collection item?', text: 'Search the UCLA Film & Television Archive Catalog at UC Library Search', name: 'UC Library Search', to: 'https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA&tab=Articles_books_more_slot&search_scope=ArticlesBooksMore&lang=en&query=any,contains,', isDark: false, svgName: 'svg-call-to-action-question' }"
+        v-bind="{ title: 'Looking for a specific collection item?', text: 'Search the UCLA Film & Television Archive Catalog at UC Library Search', name: 'UC Library Search', to: 'https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA&mode=advanced', isDark: false, svgName: 'svg-call-to-action-question' }"
       />
     </SectionWrapper>
   </main>


### PR DESCRIPTION
Connected to [APPS-3428](https://jira.library.ucla.edu/browse/APPS-3428)

**Page/Pages Created/updated:** search.vue

**Notes:**

Updated URL

**Time Report:**

This took me 1 hours to build this.

**Videos:**
Before:
https://github.com/user-attachments/assets/64fee8ed-58af-4751-ad09-72c9508e64a5

After:
https://github.com/user-attachments/assets/9ccea4c4-d593-40bd-896b-17dc3a82123e



**Checklist:**

-   [ ] I added github label for semantic versioning
-   [ ] I double checked it looks like the designs
-   [ ] I completed any required mobile breakpoint styling
-   [ ] I completed any required hover state styling
-   [ ] I included a working spec file
-   [ ] I added notes above about how long it took to build this component
-   [ ] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review
