### PR TITLE
fix: APPS-3448 expect infoblock array, add heading

### DIFF
--- a/components/BasicCollection.vue
+++ b/components/BasicCollection.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script lang="ts" setup>
 // HELPERS
 import _get from 'lodash/get'
 
@@ -21,7 +21,7 @@ const route = useRoute()
 const { data, error } = await useAsyncData(`collections-detail-${route.params.slug}`, async () => {
   const data = await $graphql.default.request(FTVACollectionDetail, { slug: route.params.slug })
   return data
-})
+}) as { data: Ref<{ ftvaCollection: any } | null>, error: Ref<any> }
 
 if (error.value) {
   throw createError({
@@ -85,8 +85,11 @@ const parsedCarouselData = computed(() => {
 // Map icon names to svg names for infoBlock
 const parsedInfoBlockIconLookup = {
   'icon-download': 'svg-call-to-action-ftva-pdf',
+  'icon-ftva-download': 'svg-call-to-action-ftva-pdf',
   'icon-info': 'svg-call-to-action-ftva-info',
-  'icon-external-link': 'svg-call-to-action-ftva-external-link-dark'
+  'icon-ftva-info': 'svg-call-to-action-ftva-info',
+  'icon-external-link': 'svg-call-to-action-ftva-external-link-dark',
+  'icon-ftva-external-link': 'svg-call-to-action-ftva-external-link-dark'
 }
 
 const parsedInfoBlock = computed(() => {
@@ -97,6 +100,7 @@ const parsedInfoBlock = computed(() => {
   return page.value.infoBlock.map((item, index) => {
     const parsedIcon = parsedInfoBlockIconLookup[item?.icon] ? parsedInfoBlockIconLookup[item.icon] : parsedInfoBlockIconLookup['icon-info']
     return {
+      ...item,
       text: item.text,
       icon: parsedIcon
     }
@@ -234,9 +238,9 @@ useHead({
           :trailer="page.videoEmbed"
         />
         <!-- TODO APPS-3326 can remove the '&& parsedInfoBlock.text' condition when we have a way to support Contact Info Data in this spot -->
-        <DividerWayFinder v-if="parsedInfoBlock && parsedInfoBlock.text" />
+        <DividerWayFinder v-if="parsedInfoBlock && parsedInfoBlock[0]?.text" />
         <div
-          v-if="parsedInfoBlock && parsedInfoBlock.text"
+          v-if="parsedInfoBlock && parsedInfoBlock[0]?.text"
           class="cta-block"
         >
           <BlockCallToAction
@@ -244,6 +248,7 @@ useHead({
             :key="item.text.concat(10)"
             :svg-name="item.icon"
             :text="item.text"
+            :title="item.heading ? item.heading : ''"
             :is-centered="false"
           />
         </div>

--- a/gql/queries/FTVACollectionDetail.gql
+++ b/gql/queries/FTVACollectionDetail.gql
@@ -32,6 +32,7 @@ query FTVACollectionDetail($slug: [String!]) {
       ... on infoBlock_infoBlock_BlockType {
         icon
         text
+        heading
       }
     }
     heroimage: ftvaHeroImage {


### PR DESCRIPTION
Connected to [APPS-3448](https://jira.library.ucla.edu/browse/APPS-3448)

**Notes:**

An earlier patch to prevent contact info blocks from crashing this page failed to include the [0] for the array item, which instead caused infoblocks to never appear. 

I also noticed that the icon names coming from craft had been changed, and a heading had been added to some data, so I added support for that. 

I honestly don't recall how long this took as it was off and on between other tasks, probably 2-3 hours

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   [X] I completed any required mobile breakpoint styling
-   [X] I completed any required hover state styling
-   [X] I included a working spec file
-   ~~[ ] I added notes above about how long it took to build this component~~
-   [X] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-3448]: https://uclalibrary.atlassian.net/browse/APPS-3448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ