### PR TITLE
feat: APPS-3472 swap title for eventTitle in now showing section

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -103,7 +103,7 @@ const parsedNowShowing = computed(() => {
     return {
       ...item,
       to: `/${item.uri}`,
-      title: item.eventTitle || item.title, //prefer eventTitle if it exists
+      title: item.eventTitle || item.title, // prefer eventTitle if it exists
       image: parseImage(item),
       startDate: item.startDateWithTime || item.startDate,
     }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -103,6 +103,7 @@ const parsedNowShowing = computed(() => {
     return {
       ...item,
       to: `/${item.uri}`,
+      title: item.eventTitle || item.title, //prefer eventTitle if it exists
       image: parseImage(item),
       startDate: item.startDateWithTime || item.startDate,
     }


### PR DESCRIPTION
Connected to [APPS-3472](https://jira.library.ucla.edu/browse/APPS-3472)

**Page/Pages Created/updated:** pages/index.vue 

**Notes:**

Since the Now Showing section data is already being parsed, I just added a bit of logic to substitute the eventTitle for the title in this specific case. 

**Time Report:**

This took me less than an hour to build this.

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   [X] I completed any required mobile breakpoint styling
-   [X] I completed any required hover state styling
-   [X] I included a working spec file
-   [X] I added notes above about how long it took to build this component
-   [X] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-3472]: https://uclalibrary.atlassian.net/browse/APPS-3472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ