### PR TITLE
fix: sort order for ongoing titles

### DIFF
--- a/gql/queries/FTVAEventSeriesList.gql
+++ b/gql/queries/FTVAEventSeriesList.gql
@@ -1,4 +1,3 @@
-#import "../gql/fragments/Image.gql"
 
 query FTVAEventSeriesList {
   entry(section: ["ftvaListingEventSeries"]) {
@@ -9,22 +8,5 @@ query FTVAEventSeriesList {
     titleGeneral
     summary
     displaySummary
-  }
-  entries(section: ["ftvaEventSeries"], orderBy: "postDate DESC") {
-    id
-    typeHandle
-    sectionHandle
-    title
-
-    ... on ftvaEventSeries_eventSeries_Entry {
-      to: slug
-      description: eventDescription
-      image: ftvaImage {
-       ...Image
-      }
-      startDate @formatDateTime(format: "Y-m-d\\TH:i:s", timezone: "America/Los_Angeles")
-      endDate @formatDateTime(format: "Y-m-d\\TH:i:s", timezone: "America/Los_Angeles")
-      ongoing
-    }
   }
 }

--- a/pages/series/index.vue
+++ b/pages/series/index.vue
@@ -20,7 +20,7 @@ if (error.value) {
   })
 }
 
-if (!data.value.entries) {
+if (!data.value.entry) {
   throw createError({
     statusCode: 404,
     statusMessage: 'Page Not Found',
@@ -98,7 +98,7 @@ const seriesFetchFunction = async (page) => {
       currentEventSeriesQueryOngoing(
         currentPage.value,
         documentsPerPage,
-        'startDate',
+        'titleSort',
         'asc',
         ['*']
       )


### PR DESCRIPTION
Connected to [APPS-3477](https://jira.library.ucla.edu/browse/APPS-3477)

This PR uses titleSort for ongoing series and removes the gql portion, which fetches event series from craft as we are using ES query to fetch event series records 

[APPS-3477]: https://uclalibrary.atlassian.net/browse/APPS-3477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ