### PR TITLE
feat: APPS-3754 update components for a11y fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@nuxtjs/eslint-config-typescript": "^12.1.0",
     "@nuxtjs/sitemap": "^5.3.5",
     "@types/node": "^18.17.3",
-    "@ucla-library/component-library-nuxt-module": "1.3.13",
+    "@ucla-library/component-library-nuxt-module": "1.3.20",
     "@zadigetvoltaire/nuxt-gtm": "^0.0.13",
     "chromatic": "^13.3.5",
     "cypress": "^15.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^18.17.3
         version: 18.19.59
       '@ucla-library/component-library-nuxt-module':
-        specifier: 1.3.13
-        version: 1.3.13(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
+        specifier: 1.3.20
+        version: 1.3.20(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
       '@zadigetvoltaire/nuxt-gtm':
         specifier: ^0.0.13
         version: 0.0.13(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.59)(eslint@8.57.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.24.0)(sass@1.80.3)(terser@5.36.0)(typescript@5.6.3)(vite@5.4.10(@types/node@18.19.59)(sass@1.80.3)(terser@5.36.0))(webpack-sources@3.3.3))(rollup@4.24.0)(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.3.3)
@@ -1438,15 +1438,15 @@ packages:
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.66.2':
-    resolution: {integrity: sha512-6Bnf7+NUedrz1P7EM7dUCbu0FWVbis18avyGtnCWTFUe45jGDi+qMbS74g7CiEQalS53LOhQvcoiWEAgCuKuKg==}
+  '@ucla-library-monorepo/ucla-library-website-components@1.68.6':
+    resolution: {integrity: sha512-8LZtWA/q7RCuLLMmLQBmkCA2VZSkuB3OM22vB5GClm/bsbslVtpwjbGoi6m7bZkIO4OEu6Wh5jMmZbFqHYCvdQ==}
     engines: {pnpm: ^9.12.1}
     peerDependencies:
       vue: ^3.5.12
       vuetify: ^3.7.4
 
-  '@ucla-library/component-library-nuxt-module@1.3.13':
-    resolution: {integrity: sha512-ywvbA4sHx3IUXlBQYeogaSPGu6qyrxhrLvRB5L7dkMZSEJPbdaV/eDjHymTuXz9oowKWjtbQvhIl+AdBHPno3w==}
+  '@ucla-library/component-library-nuxt-module@1.3.20':
+    resolution: {integrity: sha512-lSagrhWmFLCdWPjz75GO5TgCrhd5JNjivWLgI7Ve/TTyFv8v2WFXRVXrVU8N8iuzN1mWfN/WlMhtkt8U4hg3tA==}
     engines: {pnpm: ^9.12.1}
 
   '@ungap/structured-clone@1.2.0':
@@ -7393,7 +7393,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.66.2(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
+  '@ucla-library-monorepo/ucla-library-website-components@1.68.6(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
     dependencies:
       '@vuepic/vue-datepicker': 8.8.1(vue@3.5.12(typescript@5.6.3))
       '@vueuse/components': 11.3.0(vue@3.5.12(typescript@5.6.3))
@@ -7409,10 +7409,10 @@ snapshots:
       - '@vue/composition-api'
       - typescript
 
-  '@ucla-library/component-library-nuxt-module@1.3.13(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
+  '@ucla-library/component-library-nuxt-module@1.3.20(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
     dependencies:
       '@nuxt/kit': 3.16.0(magicast@0.3.5)
-      '@ucla-library-monorepo/ucla-library-website-components': 1.66.2(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
+      '@ucla-library-monorepo/ucla-library-website-components': 1.68.6(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - magicast


### PR DESCRIPTION
Connected to [APPS-3754](https://jira.library.ucla.edu/browse/APPS-3754)

**Notes:**

Pulling in all the recent a11y improvements at the component level.

I did a quick spot check using Lighthouse and I can see that the homepage has ticked from an 87 to 88 accessibility score according to their metrics. 

<img width="952" height="376" alt="Screenshot 2026-03-23 at 2 31 59 PM" src="https://github.com/user-attachments/assets/5f207470-e9e3-4203-a4f0-37a9ab3c483a" />

<img width="952" height="382" alt="Screenshot 2026-03-23 at 2 30 35 PM" src="https://github.com/user-attachments/assets/fdb5a3b2-73bd-4002-bfd3-f18ee98de850" />


**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   [X] I completed any required mobile breakpoint styling
-   [X] I completed any required hover state styling
-   [X] I included a working spec file
-   ~~[ ] I added notes above about how long it took to build this component~~
-   [ ] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-3754]: https://uclalibrary.atlassian.net/browse/APPS-3754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ