### PR TITLE
fix: LADI-5138 blog index placeholder image rules

### DIFF
--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -549,11 +549,11 @@ const pageClasses = computed(() => {
       margin: 0;
     }
 
-    :deep(.ftva.block-staff-article-item .molecule-no-image) {
-      min-width: 100%;
-      height: auto;
-      margin: 0;
-    }
+    // :deep(.ftva.block-staff-article-item .molecule-no-image) {
+    //   min-width: 100%;
+    //   height: auto;
+    //   margin: 0;
+    // }
 
     :deep(.ftva.block-staff-article-item .meta) {
       height: auto;


### PR DESCRIPTION
Connected to [LADI-5138](https://jira.library.ucla.edu/browse/LADI-5138)

**Notes:**

Since we refactored responsive image to include a placeholder, this extra set of rules basically applies twice. 

They've been removed since the rules for `.image` will apply. 

Current (broken placeholders take too much space)
https://cinema.ucla.edu/blog/

Fixed: https://deploy-preview-339--test-ftva.netlify.app/blog/

There is another PR to fix this at the story level since there are story specific styles in the component library that match these
https://github.com/UCLALibrary/ucla-library-website-components/pull/935

**Time Report:**

This took me 2ish hours to figure out the fix.

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   [X] I completed any required mobile breakpoint styling
-   [X] I completed any required hover state styling
-   [X] I included a working spec file
-   [X] I added notes above about how long it took to build this component
-   [ ] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[LADI-5138]: https://uclalibrary.atlassian.net/browse/LADI-5138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ