### PR TITLE
feat: LADI-5134 remove import statements

### DIFF
--- a/assets/styles/general-pages.scss
+++ b/assets/styles/general-pages.scss
@@ -13,7 +13,7 @@
 
       .flexible-blocks.flexible-content {
         .section-header.section-title {
-          color: $heading-grey;
+          color: ftvaTokens.$heading-grey;
         }
       }
     }

--- a/assets/styles/general-pages.scss
+++ b/assets/styles/general-pages.scss
@@ -1,4 +1,5 @@
   /* Shared styles for GeneralContent and StoryTelling templates */
+  @use 'ucla-library-design-tokens/scss/_tokens-ftva.scss' as ftvaTokens;
 
   .two-column {
     display: block;

--- a/assets/styles/listing-pages.scss
+++ b/assets/styles/listing-pages.scss
@@ -1,4 +1,5 @@
 /* These styles appear on all listing pages so far */
+@use 'ucla-library-design-tokens/scss/abstracts/' as *;
 
 // Sets an aspect ration for both the banner image and the image carousel
 .resized-aspect-ratio {

--- a/assets/styles/listing-pages.scss
+++ b/assets/styles/listing-pages.scss
@@ -1,5 +1,5 @@
 /* These styles appear on all listing pages so far */
-@use 'ucla-library-design-tokens/scss/abstracts/' as *;
+@use 'ucla-library-design-tokens/scss/app.scss' as *;
 
 // Sets an aspect ration for both the banner image and the image carousel
 .resized-aspect-ratio {

--- a/assets/styles/series-listing-pages.scss
+++ b/assets/styles/series-listing-pages.scss
@@ -1,3 +1,5 @@
+@use 'ucla-library-design-tokens/scss/app.scss' as *;
+
 .series-listing-pages {
   position: relative;
   background-color: var(--pale-blue);

--- a/assets/styles/slug-pages.scss
+++ b/assets/styles/slug-pages.scss
@@ -65,7 +65,7 @@
   // recreate cardmeta title styles for h1 slots on slugs pages
   h1.title-no-link {
     @include ftva-h2;
-    color: $heading-grey;
+    color: ftvaTokens.$heading-grey;
     margin: 0 0 24px;
   }
 
@@ -93,8 +93,8 @@
   .block-info-header {
     @include ftva-subtitle-1;
     text-align: center;
-    color: $heading-grey;
-    border-bottom: 1px solid $grey-blue;
+    color: ftvaTokens.$heading-grey;
+    border-bottom: 1px solid ftvaTokens.$grey-blue;
     padding: 8px 0;
   }
 
@@ -103,10 +103,10 @@
 
     li {
       @include ftva-body-2;
-      color: $body-grey;
+      color: ftvaTokens.$body-grey;
 
       &::marker {
-        color: $body-grey;
+        color: ftvaTokens.$body-grey;
       }
     }
   }

--- a/assets/styles/slug-pages.scss
+++ b/assets/styles/slug-pages.scss
@@ -1,4 +1,6 @@
 /* Shared styles for [slug].vue */
+@use 'ucla-library-design-tokens/scss/app.scss' as *;
+@use 'ucla-library-design-tokens/scss/_tokens-ftva.scss' as ftvaTokens;
 
 .page-detail {
 

--- a/components/ARSCIMCSSection.vue
+++ b/components/ARSCIMCSSection.vue
@@ -177,7 +177,7 @@ useHead({
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/slug-pages.scss';
+@use 'assets/styles/slug-pages.scss' as *;
 
 .one-column {
 
@@ -196,7 +196,7 @@ useHead({
 
 .section-header,
 :deep(.ftva.flexible-blocks .flexible-block-section-wrapper .section-header .section-title) {
-  color: $heading-grey;
+  color: ftvaTokens.$heading-grey;
 }
 
 :deep(.ftva.flexible-blocks .flexible-block-section-wrapper .section-header) {

--- a/components/BasicCollection.vue
+++ b/components/BasicCollection.vue
@@ -279,7 +279,7 @@ const pageClasses = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/slug-pages.scss';
+@use 'assets/styles/slug-pages.scss' as *;
 
 .page-collection-detail {
   position: relative;

--- a/components/CollectionTypeSection.vue
+++ b/components/CollectionTypeSection.vue
@@ -340,7 +340,7 @@ watch(data, (newVal, oldVal) => {
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/listing-pages.scss';
+@use 'assets/styles/listing-pages.scss' as *;
 
 .page-collection-type {
   position: relative;
@@ -376,7 +376,7 @@ watch(data, (newVal, oldVal) => {
 
     :deep(.section-title) {
       @include ftva-h4;
-      color: $heading-grey;
+      color: ftvaTokens.$heading-grey;
       font-size: 48px;
       margin-bottom: 0;
     }
@@ -386,7 +386,7 @@ watch(data, (newVal, oldVal) => {
 
       p {
         @include ftva-body-2;
-        color: $body-grey;
+        color: ftvaTokens.$body-grey;
         text-align: left;
       }
     }

--- a/components/ListOfItemsCollection.vue
+++ b/components/ListOfItemsCollection.vue
@@ -425,7 +425,7 @@ const pageClasses = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/listing-pages.scss';
+@use 'assets/styles/listing-pages.scss' as *;
 
 .page-collections-list-of-items {
   background-color: var(--pale-blue);
@@ -455,7 +455,7 @@ const pageClasses = computed(() => {
     }
 
     :deep(h2.section-header.section-header2.section-title) {
-      color: $heading-grey;
+      color: ftvaTokens.$heading-grey;
       text-align: center;
     }
 
@@ -463,41 +463,41 @@ const pageClasses = computed(() => {
       max-width: 964px;
     }
 
-  .search-filters {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    gap: 12px;
-    justify-content: flex-start;
-    margin-bottom: 2rem;
-
-    // filter dropdowns
-    :deep(.button-dropdown-modal-wrapper.is-expanded) {
-      z-index: 5;
-    }
-
-    // results pill
-    .total-results {
-      background-color: var(--dark-navy);
-      margin-left: auto; // pins the total results to the right
-      margin-right: 26px;
-      text-align: center;
-
-      @media #{$small} {
-        margin-right: 0px;
-      }
-    }
-
-    .filter-row {
+    .search-filters {
       display: flex;
       align-items: center;
-      gap: 8px;
-    }
+      width: 100%;
+      gap: 12px;
+      justify-content: flex-start;
+      margin-bottom: 2rem;
 
-    .total-results-button {
-      margin-left: auto;
+      // filter dropdowns
+      :deep(.button-dropdown-modal-wrapper.is-expanded) {
+        z-index: 5;
+      }
+
+      // results pill
+      .total-results {
+        background-color: var(--dark-navy);
+        margin-left: auto; // pins the total results to the right
+        margin-right: 26px;
+        text-align: center;
+
+        @media #{$small} {
+          margin-right: 0px;
+        }
+      }
+
+      .filter-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .total-results-button {
+        margin-left: auto;
+      }
     }
-  }
 
     .search-results-list {
       margin: 0 auto;
@@ -509,9 +509,9 @@ const pageClasses = computed(() => {
 
     @media #{$small} {
       .search-filters {
-      flex-direction: column;
-      align-items: stretch;
-      gap: 8px;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 8px;
       }
 
       /* C goes on top */

--- a/error.vue
+++ b/error.vue
@@ -119,7 +119,7 @@ useHead({
       }
 
       .blue-accent {
-        color: $accent-blue;
+        color: ftvaTokens.$accent-blue;
         font-weight: 700
       }
 
@@ -132,7 +132,7 @@ useHead({
 
       .link {
         &:hover {
-          color: $accent-blue;
+          color: ftvaTokens.$accent-blue;
           text-decoration: underline;
         }
       }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,11 +29,17 @@ export default defineNuxtConfig({
     css: {
       preprocessorOptions: {
         scss: {
-          additionalData: `
+          api: 'modern-compiler',
+          // app-global.scss starts with @forward; Sass requires @forward before any @import.
+          // A string additionalData would prepend @imports and break that file.
+          additionalData: (source: string, filename: string) => {
+            if (filename.includes('app-global.scss')) return source
+            return `
                         @import "ucla-library-design-tokens/scss/fonts.scss";
-                        @import "ucla-library-design-tokens/scss/_tokens-ftva";
+                        @import "ucla-library-design-tokens/scss/abstracts/_tokens-ftva";
                         @import "ucla-library-design-tokens/scss/app.scss";
-                    `,
+                    ${source}`
+          },
         },
       },
     }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -30,16 +30,11 @@ export default defineNuxtConfig({
       preprocessorOptions: {
         scss: {
           api: 'modern-compiler',
-          // app-global.scss starts with @forward; Sass requires @forward before any @import.
-          // A string additionalData would prepend @imports and break that file.
-          additionalData: (source: string, filename: string) => {
-            if (filename.includes('app-global.scss')) return source
-            return `
-                        @import "ucla-library-design-tokens/scss/fonts.scss";
-                        @import "ucla-library-design-tokens/scss/abstracts/_tokens-ftva";
-                        @import "ucla-library-design-tokens/scss/app.scss";
-                    ${source}`
-          },
+          additionalData: `
+            @use "ucla-library-design-tokens/scss/fonts.scss" as *;
+            @use "ucla-library-design-tokens/scss/abstracts/_tokens-ftva" as ftvaTokens;
+            @use "ucla-library-design-tokens/scss/app.scss" as *;
+          `
         },
       },
     }
@@ -182,26 +177,26 @@ export default defineNuxtConfig({
          */
         endpoint: import.meta.env.CRAFT_ENDPOINT || '',
         /**
-         * Per-client options overrides
-         * See: https://github.com/prisma-labs/graphql-request#passing-more-options-to-fetch
-         */
+       * Per-client options overrides
+       * See: https://github.com/prisma-labs/graphql-request#passing-more-options-to-fetch
+       */
         options: {},
       },
 
     },
 
     /**
-     * Options
-     * See: https://github.com/prisma-labs/graphql-request#passing-more-options-to-fetch
-     */
+   * Options
+   * See: https://github.com/prisma-labs/graphql-request#passing-more-options-to-fetch
+   */
     options: {
       method: 'get', // Default to `POST`
     },
 
     /**
-     * Optional
-     * default: false (this includes cross-fetch/polyfill before creating the graphql client)
-     */
+   * Optional
+   * default: false (this includes cross-fetch/polyfill before creating the graphql client)
+   */
     // useFetchPolyfill: true,
 
     /**

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -32,7 +32,7 @@ export default defineNuxtConfig({
           api: 'modern-compiler',
           additionalData: `
             @use "ucla-library-design-tokens/scss/fonts.scss" as *;
-            @use "ucla-library-design-tokens/scss/abstracts/_tokens-ftva" as ftvaTokens;
+            @use "ucla-library-design-tokens/scss/_tokens-ftva" as ftvaTokens;
             @use "ucla-library-design-tokens/scss/app.scss" as *;
           `
         },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lodash": "^4.17.21",
     "nuxt-graphql-request": "^7.0.5",
     "sass": "^1.66.1",
-    "ucla-library-design-tokens": "^5.56.0",
+    "ucla-library-design-tokens": "6.0.1",
     "vite-svg-loader": "^5.1.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@nuxtjs/eslint-config-typescript": "^12.1.0",
     "@nuxtjs/sitemap": "^5.3.5",
     "@types/node": "^18.17.3",
-    "@ucla-library/component-library-nuxt-module": "1.3.40",
+    "@ucla-library/component-library-nuxt-module": "1.3.44",
     "@zadigetvoltaire/nuxt-gtm": "^0.0.13",
     "chromatic": "^13.3.5",
     "cypress": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lodash": "^4.17.21",
     "nuxt-graphql-request": "^7.0.5",
     "sass": "^1.66.1",
-    "ucla-library-design-tokens": "6.0.1",
+    "ucla-library-design-tokens": "6.0.2",
     "vite-svg-loader": "^5.1.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@nuxtjs/eslint-config-typescript": "^12.1.0",
     "@nuxtjs/sitemap": "^5.3.5",
     "@types/node": "^18.17.3",
-    "@ucla-library/component-library-nuxt-module": "1.3.44",
+    "@ucla-library/component-library-nuxt-module": "1.3.46",
     "@zadigetvoltaire/nuxt-gtm": "^0.0.13",
     "chromatic": "^13.3.5",
     "cypress": "^15.0.0",

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -217,9 +217,9 @@ onMounted(() => {
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/slug-pages.scss';
-@import 'assets/styles/general-pages.scss';
-@import 'assets/styles/page-anchor.scss';
+@use 'assets/styles/slug-pages.scss' as *;
+@use 'assets/styles/general-pages.scss' as *;
+@use 'assets/styles/page-anchor.scss' as *;
 
 .page-general-content {
 

--- a/pages/billy-wilder-theater.vue
+++ b/pages/billy-wilder-theater.vue
@@ -306,7 +306,7 @@ const pageClasses = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/slug-pages.scss';
+@use 'assets/styles/slug-pages.scss' as *;
 
 .billy-wilder-theater {
   .one-column {
@@ -421,7 +421,7 @@ const pageClasses = computed(() => {
 
   .map-address {
     @include ftva-emphasized-subtitle;
-    color: $accent-blue;
+    color: ftvaTokens.$accent-blue;
   }
 
   .iframe-wrapper {
@@ -453,7 +453,7 @@ const pageClasses = computed(() => {
   .section-subtitle,
   .map-title,
   .map-note {
-    color: $heading-grey;
+    color: ftvaTokens.$heading-grey;
   }
 
   @media #{$medium} {

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -252,7 +252,7 @@ const parseBlocks = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/slug-pages.scss';
+@use 'assets/styles/slug-pages.scss' as *;
 
 // PAGE STYLES
 .page-article-detail {
@@ -302,7 +302,7 @@ const parseBlocks = computed(() => {
 
   .about-the-author {
     @include ftva-subtitle-2;
-    color: $accent-blue;
+    color: ftvaTokens.$accent-blue;
     padding-bottom: 4px;
   }
 

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -293,7 +293,7 @@ const pageClasses = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/listing-pages.scss';
+@use 'assets/styles/listing-pages.scss' as *;
 
 .page-article-list {
   position: relative;
@@ -417,7 +417,7 @@ const pageClasses = computed(() => {
     :deep(.section-header) {
       font-size: 38px;
       margin-bottom: 48px;
-      color: $heading-grey;
+      color: ftvaTokens.$heading-grey;
     }
 
     &:last-of-type {
@@ -501,7 +501,7 @@ const pageClasses = computed(() => {
 
   :deep(.ftva.block-staff-article-item) {
     .ftva-date {
-      color: $subtitle-grey;
+      color: ftvaTokens.$subtitle-grey;
       font-family: "proxima-nova", Helvetica, Arial, sans-serif;
       font-size: 16px;
       font-style: normal;

--- a/pages/collections/[collectionSlug]/[slug].vue
+++ b/pages/collections/[collectionSlug]/[slug].vue
@@ -398,7 +398,7 @@ const pageClasses = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/slug-pages.scss';
+@use 'assets/styles/slug-pages.scss' as *;
 
 .page-collection-item-detail {
   position: relative;
@@ -485,7 +485,7 @@ const pageClasses = computed(() => {
 
   .collection-item-subtitle {
     @include ftva-h3;
-    color: $heading-grey;
+    color: ftvaTokens.$heading-grey;
 
     &.synopsis {
       margin-top: var(--space-m);
@@ -536,7 +536,7 @@ const pageClasses = computed(() => {
 
   .credit-table__name {
     font-size: 30px;
-    color: $accent-blue;
+    color: ftvaTokens.$accent-blue;
   }
 
   @media(max-width: 1200px) {

--- a/pages/collections/index.vue
+++ b/pages/collections/index.vue
@@ -312,7 +312,7 @@ const pageClasses = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/listing-pages.scss';
+@use 'assets/styles/listing-pages.scss' as *;
 
 .page-explore-collections {
   position: relative;
@@ -372,7 +372,7 @@ const pageClasses = computed(() => {
     }
 
     :deep(.section-title) {
-      color: $heading-grey;
+      color: ftvaTokens.$heading-grey;
     }
 
     :deep(.rich-text.section-summary) {
@@ -404,7 +404,7 @@ const pageClasses = computed(() => {
 
   .section-wrapper-hearst {
     :deep(.section-title) {
-      color: $heading-grey;
+      color: ftvaTokens.$heading-grey;
     }
 
     .block-highlight {
@@ -442,7 +442,7 @@ const pageClasses = computed(() => {
 
   :deep(.section-wrapper-post-small) {
     .section-title {
-      color: $heading-grey;
+      color: ftvaTokens.$heading-grey;
     }
 
     .rich-text {

--- a/pages/collections/la-rebellion/filmmakers/[slug].vue
+++ b/pages/collections/la-rebellion/filmmakers/[slug].vue
@@ -241,7 +241,7 @@ const pageClasses = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/slug-pages.scss';
+@use 'assets/styles/slug-pages.scss' as *;
 
 .page-filmmaker-detail {
   position: relative;

--- a/pages/collections/la-rebellion/filmmakers/index.vue
+++ b/pages/collections/la-rebellion/filmmakers/index.vue
@@ -269,7 +269,7 @@ const breadcrumbOverrides = ref([
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/listing-pages.scss';
+@use 'assets/styles/listing-pages.scss' as *;
 
 .page-filmmakers {
   position: relative;
@@ -281,7 +281,7 @@ const breadcrumbOverrides = ref([
 
     :deep(.section-title) {
       @include ftva-h5;
-      color: $heading-grey;
+      color: ftvaTokens.$heading-grey;
     }
 
     :deep(.section-summary) {

--- a/pages/collections/la-rebellion/index.vue
+++ b/pages/collections/la-rebellion/index.vue
@@ -228,9 +228,9 @@ const pageClasses = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/slug-pages.scss';
-@import 'assets/styles/general-pages.scss';
-@import 'assets/styles/page-anchor.scss';
+@use 'assets/styles/slug-pages.scss' as *;
+@use 'assets/styles/general-pages.scss' as *;
+@use 'assets/styles/page-anchor.scss' as *;
 
 .page-storytelling {
   :deep(.card-with-image) {
@@ -256,7 +256,7 @@ const pageClasses = computed(() => {
 
     .section-title {
       @include ftva-h5;
-      color: $heading-grey;
+      color: ftvaTokens.$heading-grey;
     }
 
     .block-post-small {

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -338,7 +338,7 @@ const pageClasses = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/slug-pages.scss';
+@use 'assets/styles/slug-pages.scss' as *;
 
 .page-event-detail {
   position: relative;

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -632,7 +632,7 @@ const pageClasses = computed(() => {
 </template>
 
 <style lang='scss' scoped>
-@import 'assets/styles/listing-pages.scss';
+@use 'assets/styles/listing-pages.scss' as *;
 
 :deep(.button-dropdown-modal-wrapper.is-expanded) {
   z-index: 99;
@@ -830,7 +830,7 @@ const pageClasses = computed(() => {
     }
 
     :deep(.section-teaser-list .list-item) {
-      border-bottom: 1px solid $page-blue;
+      border-bottom: 1px solid ftvaTokens.$page-blue;
 
       &:last-child {
         border-bottom: 0;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -479,7 +479,7 @@ const pageClasses = computed(() => {
   }
 
   :deep(.section-wrapper h2.section-header.section-title) {
-    color: $heading-grey;
+    color: ftvaTokens.$heading-grey;
   }
 
   // Make all images the same in FPB Media With Text
@@ -510,12 +510,12 @@ const pageClasses = computed(() => {
 
       .smart-link.title {
         @include ftva-card-title-1;
-        color: $heading-grey;
+        color: ftvaTokens.$heading-grey;
       }
 
       .date-time {
         @include ftva-emphasized-subtitle;
-        color: $accent-blue;
+        color: ftvaTokens.$accent-blue;
         margin-bottom: 0px;
 
         .schedule-item.start-date {
@@ -599,7 +599,7 @@ const pageClasses = computed(() => {
     :deep(.ftva.card-meta a.title) {
       overflow: initial;
       @include ftva-h5;
-      color: $heading-grey;
+      color: ftvaTokens.$heading-grey;
 
       &:hover {
         text-decoration: underline;
@@ -639,7 +639,7 @@ const pageClasses = computed(() => {
         .title {
           margin-top: 0px;
           @include ftva-h5;
-          color: $heading-grey;
+          color: ftvaTokens.$heading-grey;
 
           &:hover {
             text-decoration: underline;

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -519,7 +519,7 @@ const pageClasses = computed(() => {
           v-show="!noResultsFound
             &&
             totalResults > 0
-          "
+            "
           ref="el"
           class="results"
         >
@@ -619,11 +619,11 @@ const pageClasses = computed(() => {
       padding-left: 2rem;
       line-height: 1.2;
       @include ftva-h4;
-      color: $medium-grey;
+      color: ftvaTokens.$medium-grey;
 
       .search-keywords {
         @include ftva-h3;
-        color: $heading-grey;
+        color: ftvaTokens.$heading-grey;
       }
     }
 
@@ -633,18 +633,18 @@ const pageClasses = computed(() => {
 
       .bottom-row {
         @include ftva-breadcrumb-inactive;
-        color: $medium-grey;
+        color: ftvaTokens.$medium-grey;
 
         .bottom-link {
           @include ftva-button-link;
-          color: $accent-blue;
+          color: ftvaTokens.$accent-blue;
         }
       }
     }
   }
 
   :deep(.ftva.block-call-to-action.theme-light) {
-    background-color: $white;
+    background-color: ftvaTokens.$white;
   }
 
   .two-column {
@@ -729,12 +729,12 @@ const pageClasses = computed(() => {
 
         .no-results-title {
           @include ftva-h4;
-          color: $heading-grey;
+          color: ftvaTokens.$heading-grey;
         }
 
         .no-results-text {
           @include ftva-breadcrumb-inactive;
-          color: $heading-grey;
+          color: ftvaTokens.$heading-grey;
         }
       }
 
@@ -753,7 +753,7 @@ const pageClasses = computed(() => {
 
       .filter-results {
         @include ftva-card-title-1;
-        color: $medium-grey;
+        color: ftvaTokens.$medium-grey;
         margin-bottom: 2rem;
       }
 

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -514,7 +514,7 @@ useHead({
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/slug-pages.scss';
+@use 'assets/styles/slug-pages.scss' as *;
 
 // GENERAL PAGE STYLES / DESKTOP
 .page-event-series-detail {
@@ -652,7 +652,7 @@ useHead({
     }
 
     :deep(.section-teaser-list .list-item) {
-      border-bottom: 1px solid $page-blue;
+      border-bottom: 1px solid ftvaTokens.$page-blue;
 
       &:last-child {
         border-bottom: 0;

--- a/pages/series/index.vue
+++ b/pages/series/index.vue
@@ -258,6 +258,6 @@ const pageClasses = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/listing-pages.scss';
-@import 'assets/styles/series-listing-pages.scss';
+@use 'assets/styles/listing-pages.scss' as *;
+@use 'assets/styles/series-listing-pages.scss' as *;
 </style>

--- a/pages/touring-series/[slug].vue
+++ b/pages/touring-series/[slug].vue
@@ -251,7 +251,7 @@ useHead({
 
 <style lang="scss" scoped>
 // TODO Make the table in FPB RichText component responsive
-@import 'assets/styles/slug-pages.scss';
+@use 'assets/styles/slug-pages.scss' as *;
 
 .page-touring-series-detail {
   .tour-dates {

--- a/pages/touring-series/[slug].vue
+++ b/pages/touring-series/[slug].vue
@@ -276,7 +276,7 @@ useHead({
 
   .completed-tour {
     @include ftva-body;
-    color: $medium-grey;
+    color: FtvaTokens.$medium-grey;
     margin-bottom: 24px;
   }
 

--- a/pages/touring-series/[slug].vue
+++ b/pages/touring-series/[slug].vue
@@ -276,7 +276,7 @@ useHead({
 
   .completed-tour {
     @include ftva-body;
-    color: FtvaTokens.$medium-grey;
+    color: ftvaTokens.$medium-grey;
     margin-bottom: 24px;
   }
 

--- a/pages/touring-series/index.vue
+++ b/pages/touring-series/index.vue
@@ -285,6 +285,6 @@ const pageClasses = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import 'assets/styles/listing-pages.scss';
-@import 'assets/styles/series-listing-pages.scss';
+@use 'assets/styles/listing-pages.scss' as *;
+@use 'assets/styles/series-listing-pages.scss' as *;
 </style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: ^1.66.1
         version: 1.80.3
       ucla-library-design-tokens:
-        specifier: ^5.56.0
-        version: 5.56.0
+        specifier: 6.0.1
+        version: 6.0.1
       vite-svg-loader:
         specifier: ^5.1.0
         version: 5.1.0(vue@3.5.12(typescript@5.6.3))
@@ -5275,8 +5275,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ucla-library-design-tokens@5.56.0:
-    resolution: {integrity: sha512-J7047TOVuuI56n3Grrw0Ja/4zNl7BmYhu0HRGjbVeH2ryeNfsVpImsVuYYDCIktuF7bKbSChu24peFIH/ijgbg==}
+  ucla-library-design-tokens@6.0.1:
+    resolution: {integrity: sha512-ilqZrjf3P7y6ByVqbUKeI5QvBXBOL5BTZVj+EAeCDddQa5FzwgdxlM2KCvzrm1na+62CrfanxStrOkVliAXAxw==}
 
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
@@ -11860,7 +11860,7 @@ snapshots:
 
   typescript@5.6.3: {}
 
-  ucla-library-design-tokens@5.56.0: {}
+  ucla-library-design-tokens@6.0.1: {}
 
   ufo@1.5.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^18.17.3
         version: 18.19.59
       '@ucla-library/component-library-nuxt-module':
-        specifier: 1.3.40
-        version: 1.3.40(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
+        specifier: 1.3.44
+        version: 1.3.44(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
       '@zadigetvoltaire/nuxt-gtm':
         specifier: ^0.0.13
         version: 0.0.13(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.59)(eslint@8.57.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.24.0)(sass@1.80.3)(terser@5.36.0)(typescript@5.6.3)(vite@5.4.10(@types/node@18.19.59)(sass@1.80.3)(terser@5.36.0))(webpack-sources@3.3.3))(rollup@4.24.0)(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.3.3)
@@ -1441,15 +1441,15 @@ packages:
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.75.2':
-    resolution: {integrity: sha512-xn1uqdWNWvm7TSrSdkVNzB52+UUvLDCXc45JwbYX0wmI61KATED1VbuO8A15rTEuAfrZXs+ub4iOKvA8WfNwHg==}
+  '@ucla-library-monorepo/ucla-library-website-components@1.76.2':
+    resolution: {integrity: sha512-oLSzyKg1CS3HYywTtwLyJoHF9ap3lx37KB1K9lZV967sVYWYGz9OI2/OahZWRX3NrtgWRs7CjNPB1PSk10Udgw==}
     engines: {pnpm: ^9.12.1}
     peerDependencies:
       vue: ^3.5.12
       vuetify: ^3.7.4
 
-  '@ucla-library/component-library-nuxt-module@1.3.40':
-    resolution: {integrity: sha512-wR24gM449KDM0ScMWeYRDq6K2e5Y4ZmQmgeH7BwW5a6zNx5Y5kdprz+Le/oiDeOWcXhjchsj9ZIHfKjeq9VTzQ==}
+  '@ucla-library/component-library-nuxt-module@1.3.44':
+    resolution: {integrity: sha512-A4q7dxqePBgPD3D64U4CjQnQ/8fZ9tPFTdMWVlcOTVfIyxsqaAs+70TSOMnKAU6MIFuw75/iafR25hZmTFwdlw==}
     engines: {pnpm: ^9.12.1}
 
   '@ungap/structured-clone@1.2.0':
@@ -7388,7 +7388,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.75.2(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
+  '@ucla-library-monorepo/ucla-library-website-components@1.76.2(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
     dependencies:
       '@vuepic/vue-datepicker': 8.8.1(vue@3.5.12(typescript@5.6.3))
       '@vueuse/components': 11.3.0(vue@3.5.12(typescript@5.6.3))
@@ -7404,10 +7404,10 @@ snapshots:
       - '@vue/composition-api'
       - typescript
 
-  '@ucla-library/component-library-nuxt-module@1.3.40(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
+  '@ucla-library/component-library-nuxt-module@1.3.44(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
     dependencies:
       '@nuxt/kit': 3.16.0(magicast@0.3.5)
-      '@ucla-library-monorepo/ucla-library-website-components': 1.75.2(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
+      '@ucla-library-monorepo/ucla-library-website-components': 1.76.2(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - magicast

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         specifier: ^1.66.1
         version: 1.80.3
       ucla-library-design-tokens:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 6.0.2
+        version: 6.0.2
       vite-svg-loader:
         specifier: ^5.1.0
         version: 5.1.0(vue@3.5.12(typescript@5.6.3))
@@ -5270,8 +5270,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ucla-library-design-tokens@6.0.1:
-    resolution: {integrity: sha512-ilqZrjf3P7y6ByVqbUKeI5QvBXBOL5BTZVj+EAeCDddQa5FzwgdxlM2KCvzrm1na+62CrfanxStrOkVliAXAxw==}
+  ucla-library-design-tokens@6.0.2:
+    resolution: {integrity: sha512-ej52KPWP1BiV9cDc+l2IjvwtkDa45/iyxbi42u5hyVAoQaFKdo4X84hk5QinYn4e+9WwmUbnbHWWxgm6dwGmBQ==}
 
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
@@ -11853,7 +11853,7 @@ snapshots:
 
   typescript@5.6.3: {}
 
-  ucla-library-design-tokens@6.0.1: {}
+  ucla-library-design-tokens@6.0.2: {}
 
   ufo@1.5.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^18.17.3
         version: 18.19.59
       '@ucla-library/component-library-nuxt-module':
-        specifier: 1.3.44
-        version: 1.3.44(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
+        specifier: 1.3.46
+        version: 1.3.46(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
       '@zadigetvoltaire/nuxt-gtm':
         specifier: ^0.0.13
         version: 0.0.13(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.59)(eslint@8.57.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.24.0)(sass@1.80.3)(terser@5.36.0)(typescript@5.6.3)(vite@5.4.10(@types/node@18.19.59)(sass@1.80.3)(terser@5.36.0))(webpack-sources@3.3.3))(rollup@4.24.0)(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.3.3)
@@ -1441,15 +1441,15 @@ packages:
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.76.2':
-    resolution: {integrity: sha512-oLSzyKg1CS3HYywTtwLyJoHF9ap3lx37KB1K9lZV967sVYWYGz9OI2/OahZWRX3NrtgWRs7CjNPB1PSk10Udgw==}
+  '@ucla-library-monorepo/ucla-library-website-components@1.77.1':
+    resolution: {integrity: sha512-GWXhl1slfVhAFomkU3e/fQU2N6E7Tl5CIs1qcEEij3eY62Ta/9FMdes7rU3/stJZUB+9A53F7XrXoMkrLbLi8w==}
     engines: {pnpm: ^9.12.1}
     peerDependencies:
       vue: ^3.5.12
       vuetify: ^3.7.4
 
-  '@ucla-library/component-library-nuxt-module@1.3.44':
-    resolution: {integrity: sha512-A4q7dxqePBgPD3D64U4CjQnQ/8fZ9tPFTdMWVlcOTVfIyxsqaAs+70TSOMnKAU6MIFuw75/iafR25hZmTFwdlw==}
+  '@ucla-library/component-library-nuxt-module@1.3.46':
+    resolution: {integrity: sha512-Exc456P8/P3T31YlSnQVEKSPgFugMsTw6K0oyG8MXHNoehu1HL9k3MUqFZjFELpH2ehlZKxOTNamyz3aefRz9g==}
     engines: {pnpm: ^9.12.1}
 
   '@ungap/structured-clone@1.2.0':
@@ -7388,7 +7388,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.76.2(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
+  '@ucla-library-monorepo/ucla-library-website-components@1.77.1(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
     dependencies:
       '@vuepic/vue-datepicker': 8.8.1(vue@3.5.12(typescript@5.6.3))
       '@vueuse/components': 11.3.0(vue@3.5.12(typescript@5.6.3))
@@ -7404,10 +7404,10 @@ snapshots:
       - '@vue/composition-api'
       - typescript
 
-  '@ucla-library/component-library-nuxt-module@1.3.44(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
+  '@ucla-library/component-library-nuxt-module@1.3.46(magicast@0.3.5)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))':
     dependencies:
       '@nuxt/kit': 3.16.0(magicast@0.3.5)
-      '@ucla-library-monorepo/ucla-library-website-components': 1.76.2(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
+      '@ucla-library-monorepo/ucla-library-website-components': 1.77.1(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(vuetify@3.7.4(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - magicast


### PR DESCRIPTION
Connected to [LADI-5134](https://jira.library.ucla.edu/browse/LADI-5134)

**Notes:**

Removes all `@import` statements from stylesheets and `<style>` tags (does not impact vue component imports)
and replaces them with `@use` statements

**Time Report:**

This took me 4ish hours to build & test this.

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   [X] I included a working spec file
-   [X] I added notes above about how long it took to build this component
-   [X] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[LADI-5134]: https://uclalibrary.atlassian.net/browse/LADI-5134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ