### PR TITLE
feat: LADI-3717 add sizes data

### DIFF
--- a/components/ARSCIMCSSection.vue
+++ b/components/ARSCIMCSSection.vue
@@ -82,7 +82,7 @@ const pageClasses = computed(() => {
 
 // START Handle Hero Image or Carousel
 // Hero Image - formats object with 'creditText' and 'image' fields
-const parsedImage = computed(() => Array.isArray(page.value?.imageCarousel) ? page.value.imageCarousel.map((imageObj, index) => (index === 0 && imageObj ? { ...imageObj, image: [{ ...imageObj.image[0], sizes: '(min-width: 1220px) 1160px, (min-width: 760px) calc(90.91vw - 59px), calc(100vw - 48px)' }] } : imageObj)) : [])
+const parsedImage = computed(() => Array.isArray(page.value?.imageCarousel) ? page.value.imageCarousel.map((imageObj, index) => (index === 0 && imageObj ? { ...imageObj, image: [{ ...imageObj.image[0], sizes: '(min-width: 1220px) 1160px, (min-width: 760px) 92vw, 100vw' }] } : imageObj)) : [])
 // Carousel - formats object with 'credit' and 'item' fields
 // 1 Carousel data types
 interface FtvaImage {
@@ -99,7 +99,7 @@ const parsedCarouselData = computed<ParsedCarouselItem[]>(() => {
   return parsedImage.value.map((rawItem) => {
     const firstImage = rawItem?.image?.[0]
     return {
-      item: firstImage ? [{ ...firstImage, kind: 'image', sizes: '(min-width: 1220px) 1160px, (min-width: 760px) calc(90.91vw - 59px), calc(100vw - 48px)' }] : [],
+      item: firstImage ? [{ ...firstImage, kind: 'image', sizes: '(min-width: 1220px) 1160px, (min-width: 760px) 92vw, 100vw' }] : [],
       credit: rawItem?.creditText ?? '',
     }
   })

--- a/components/ARSCIMCSSection.vue
+++ b/components/ARSCIMCSSection.vue
@@ -72,6 +72,32 @@ watch(data, (newVal, oldVal) => {
 // Parse FlexibleBlock with helper
 const parsedFlexibleBlocks = computed(() => {
   const dataBlocks = page.value?.blocks || []
+
+  // add sizes data to various flexible block types
+  dataBlocks.forEach((block) => {
+    if (block.typeHandle === 'cardWithImage' && block.cardWithImage?.length > 0) {
+      // block.cardWithImage[0].image = [{ ...block.cardWithImage[0].image[0], sizes: '322px' }]
+      block.cardWithImage.forEach((card) => {
+        card.image.forEach((image) => {
+          image.sizes = '322px'
+        })
+      })
+    }
+    if (block.typeHandle === 'mediaWithText' && block.mediaWithText?.length > 0) {
+      block.mediaWithText.forEach((media) => {
+        media.coverImage?.forEach((image) => {
+          image.sizes = '(min-width: 1000px) 400px, (min-width: 760px) calc(112.27vw - 140px), calc(112.95vw - 55px)'
+        })
+      })
+    }
+    if (block.typeHandle === 'mediaGallery' && block.mediaGallery?.length > 0) {
+      block.mediaGallery.forEach((gallery) => {
+        gallery.item?.forEach((image) => {
+          image.sizes = '(min-width: 1360px) 1160px, (min-width: 760px) calc(91.03vw - 60px), calc(100vw - 48px)'
+        })
+      })
+    }
+  })
   return parseFlexibleBlocks(dataBlocks)
 })
 
@@ -82,7 +108,7 @@ const pageClasses = computed(() => {
 
 // START Handle Hero Image or Carousel
 // Hero Image - formats object with 'creditText' and 'image' fields
-const parsedImage = computed(() => Array.isArray(page.value?.imageCarousel) ? page.value.imageCarousel.map((imageObj, index) => (index === 0 && imageObj ? { ...imageObj, image: [{ ...imageObj.image[0], sizes: '(min-width: 1220px) 1160px, (min-width: 760px) 92vw, 100vw' }] } : imageObj)) : [])
+const parsedImage = computed(() => Array.isArray(page.value?.imageCarousel) ? page.value.imageCarousel.map((imageObj, index) => (index === 0 && imageObj ? { ...imageObj, image: [{ ...imageObj.image[0], sizes: '(min-width: 1220px) 1160px, (min-width: 760px) calc(90.91vw - 59px), calc(100vw - 48px)' }] } : imageObj)) : [])
 // Carousel - formats object with 'credit' and 'item' fields
 // 1 Carousel data types
 interface FtvaImage {
@@ -99,7 +125,7 @@ const parsedCarouselData = computed<ParsedCarouselItem[]>(() => {
   return parsedImage.value.map((rawItem) => {
     const firstImage = rawItem?.image?.[0]
     return {
-      item: firstImage ? [{ ...firstImage, kind: 'image', sizes: '(min-width: 1220px) 1160px, (min-width: 760px) 92vw, 100vw' }] : [],
+      item: firstImage ? [{ ...firstImage, kind: 'image', sizes: '(min-width: 1220px) 1160px, (min-width: 760px) calc(90.91vw - 59px), calc(100vw - 48px)' }] : [],
       credit: rawItem?.creditText ?? '',
     }
   })

--- a/components/ARSCIMCSSection.vue
+++ b/components/ARSCIMCSSection.vue
@@ -69,37 +69,10 @@ watch(data, (newVal, oldVal) => {
   page.value = _get(newVal, 'entry', {})
 })
 
-// Parse FlexibleBlock with helper
-const parsedFlexibleBlocks = computed(() => {
-  const dataBlocks = page.value?.blocks || []
-
-  // add sizes data to various flexible block types
-  dataBlocks.forEach((block) => {
-    if (block.typeHandle === 'cardWithImage' && block.cardWithImage?.length > 0) {
-      // block.cardWithImage[0].image = [{ ...block.cardWithImage[0].image[0], sizes: '322px' }]
-      block.cardWithImage.forEach((card) => {
-        card.image.forEach((image) => {
-          image.sizes = '322px'
-        })
-      })
-    }
-    if (block.typeHandle === 'mediaWithText' && block.mediaWithText?.length > 0) {
-      block.mediaWithText.forEach((media) => {
-        media.coverImage?.forEach((image) => {
-          image.sizes = '(min-width: 1000px) 400px, (min-width: 760px) calc(112.27vw - 140px), calc(112.95vw - 55px)'
-        })
-      })
-    }
-    if (block.typeHandle === 'mediaGallery' && block.mediaGallery?.length > 0) {
-      block.mediaGallery.forEach((gallery) => {
-        gallery.item?.forEach((image) => {
-          image.sizes = '(min-width: 1360px) 1160px, (min-width: 760px) calc(91.03vw - 60px), calc(100vw - 48px)'
-        })
-      })
-    }
-  })
-  return parseFlexibleBlocks(dataBlocks)
-})
+// Parse FlexibleBlock with helper (sizes for image blocks applied in util when flag is set)
+const parsedFlexibleBlocks = computed(() =>
+  parseFlexibleBlocks(page.value?.blocks || [], { withResponsiveImageSizes: true }),
+)
 
 const pageClasses = computed(() => {
   const slugClass = props.canonicalPath.slice(1).replaceAll('/', '-')

--- a/components/ARSCIMCSSection.vue
+++ b/components/ARSCIMCSSection.vue
@@ -75,36 +75,36 @@ const parsedFlexibleBlocks = computed(() => {
   return parseFlexibleBlocks(dataBlocks)
 })
 
-/** 7) Make a safe, CSS-friendly class from the path */
 const pageClasses = computed(() => {
   const slugClass = props.canonicalPath.slice(1).replaceAll('/', '-')
   return ['page', 'page-detail', 'page-detail--paleblue', slugClass, 'page-bottom-spacer']
 })
 
-/** 5) Always return an array */
-const parsedImage = computed(() => Array.isArray(page.value?.imageCarousel) ? page.value.imageCarousel : [])
-
+// START Handle Hero Image or Carousel
+// Hero Image - formats object with 'creditText' and 'image' fields
+const parsedImage = computed(() => Array.isArray(page.value?.imageCarousel) ? page.value.imageCarousel.map((imageObj, index) => (index === 0 && imageObj ? { ...imageObj, image: [{ ...imageObj.image[0], sizes: '(min-width: 1220px) 1160px, (min-width: 760px) calc(90.91vw - 59px), calc(100vw - 48px)' }] } : imageObj)) : [])
+// Carousel - formats object with 'credit' and 'item' fields
+// 1 Carousel data types
 interface FtvaImage {
   // adapt to your actual image fields as needed
   [k: string]: unknown
 }
-
 type ParsedCarouselItem = {
   item: Array<FtvaImage & { kind: 'image' }>
   creditText: string
 }
-
-/** 5 & 6) Guard and use consistent prop name 'credit' throughout */
+// 2 Carousel data parsing
 const parsedCarouselData = computed<ParsedCarouselItem[]>(() => {
   if (!Array.isArray(parsedImage.value) || parsedImage.value.length === 0) return []
   return parsedImage.value.map((rawItem) => {
     const firstImage = rawItem?.image?.[0]
     return {
-      item: firstImage ? [{ ...firstImage, kind: 'image' }] : [],
+      item: firstImage ? [{ ...firstImage, kind: 'image', sizes: '(min-width: 1220px) 1160px, (min-width: 760px) calc(90.91vw - 59px), calc(100vw - 48px)' }] : [],
       credit: rawItem?.creditText ?? '',
     }
   })
 })
+// END Handle Hero Image or Carousel
 
 const headTitle = computed(() => page.value?.title || 'Loading ...')
 

--- a/utils/parseFlexibleBlocks.js
+++ b/utils/parseFlexibleBlocks.js
@@ -80,6 +80,7 @@ function parseSimpleCard(block) {
 const SIZES_CARD_WITH_IMAGE = '322px'
 const SIZES_MEDIA_WITH_TEXT =
   '(min-width: 1000px) 400px, (min-width: 760px) calc(112.27vw - 140px), calc(112.95vw - 55px)'
+// media gallery shows images at 2 sizes, so we are including sizes data for the larger size
 const SIZES_MEDIA_GALLERY =
   '(min-width: 1360px) 1160px, (min-width: 760px) calc(91.03vw - 60px), calc(100vw - 48px)'
 

--- a/utils/parseFlexibleBlocks.js
+++ b/utils/parseFlexibleBlocks.js
@@ -99,10 +99,15 @@ function applyResponsiveImageSizes (block) {
     }
   }
   if (block.typeHandle === 'mediaWithText' && block.mediaWithText?.length > 0) {
+    // need to add sizes data to item if it exists and to coverImage if it exists
     return {
       ...block,
       mediaWithText: block.mediaWithText.map(media => ({
         ...media,
+        item: media.item?.map(image => ({
+          ...image,
+          sizes: SIZES_MEDIA_WITH_TEXT,
+        })),
         coverImage: media.coverImage?.map(image => ({
           ...image,
           sizes: SIZES_MEDIA_WITH_TEXT,

--- a/utils/parseFlexibleBlocks.js
+++ b/utils/parseFlexibleBlocks.js
@@ -1,4 +1,5 @@
 // Helper to parse FlexibleBlocks on the General Content and ARSCIMCS templates. Parses data for InfoBlock and SimpleCards.
+// Optional responsive `sizes` for blocks containing images.
 
 // ***** INFO BLOCK ***** //
 
@@ -76,17 +77,71 @@ function parseSimpleCard(block) {
 
 // ***** FLEXIBLE BLOCKS ***** //
 
-function parseFlexibleBlocks (blocks) {
+const SIZES_CARD_WITH_IMAGE = '322px'
+const SIZES_MEDIA_WITH_TEXT =
+  '(min-width: 1000px) 400px, (min-width: 760px) calc(112.27vw - 140px), calc(112.95vw - 55px)'
+const SIZES_MEDIA_GALLERY =
+  '(min-width: 1360px) 1160px, (min-width: 760px) calc(91.03vw - 60px), calc(100vw - 48px)'
+
+/** Clone only branches that need `sizes` for ResponsiveImage; avoids mutating CMS data. */
+function applyResponsiveImageSizes (block) {
+  if (block.typeHandle === 'cardWithImage' && block.cardWithImage?.length > 0) {
+    return {
+      ...block,
+      cardWithImage: block.cardWithImage.map(card => ({
+        ...card,
+        image: (card.image || []).map(image => ({
+          ...image,
+          sizes: SIZES_CARD_WITH_IMAGE,
+        })),
+      })),
+    }
+  }
+  if (block.typeHandle === 'mediaWithText' && block.mediaWithText?.length > 0) {
+    return {
+      ...block,
+      mediaWithText: block.mediaWithText.map(media => ({
+        ...media,
+        coverImage: media.coverImage?.map(image => ({
+          ...image,
+          sizes: SIZES_MEDIA_WITH_TEXT,
+        })),
+      })),
+    }
+  }
+  if (block.typeHandle === 'mediaGallery' && block.mediaGallery?.length > 0) {
+    return {
+      ...block,
+      mediaGallery: block.mediaGallery.map(gallery => ({
+        ...gallery,
+        item: gallery.item?.map(image => ({
+          ...image,
+          sizes: SIZES_MEDIA_GALLERY,
+        })),
+      })),
+    }
+  }
+  return block
+}
+
+/**
+ * @param {unknown[]} blocks
+ * @param {{ withResponsiveImageSizes?: boolean }} [options]
+ */
+function parseFlexibleBlocks (blocks, options = {}) {
+  const { withResponsiveImageSizes = false } = options
   return blocks.map((block) => {
-    if (block.typeHandle === 'infoBlock') {
-      block = parseInfoBlockAddress(block)
+    let newBlock = withResponsiveImageSizes ? applyResponsiveImageSizes(block) : block
+
+    if (newBlock.typeHandle === 'infoBlock') {
+      newBlock = parseInfoBlockAddress(newBlock)
     }
 
-    if (block.typeHandle === 'simpleCards') {
-      block = parseSimpleCard(block)
+    if (newBlock.typeHandle === 'simpleCards') {
+      newBlock = parseSimpleCard(newBlock)
     }
 
-    return block
+    return newBlock
   })
 }
 


### PR DESCRIPTION
Connected to [LADI-3717](https://jira.library.ucla.edu/browse/LADI-3717)

**Notes:**

- removed some extra AI comments that diplicated #'s and had things out of order
- added sizes data to ARSCIMCS
- tested in Lighthouse 
- noticed performance had not improved
- integrated the sizes logic into parseFlexibleBlocks so we don't have to loop through blocks twice
- removed mutations to page.blocks and created clones instead
- checked performance again and saw improvement

before: 1250 kib image delivery to improve, render blocking requests 800ms
<img width="559" height="711" alt="Screenshot 2026-05-12 at 11 44 59 AM" src="https://github.com/user-attachments/assets/a1c15476-b523-4f80-9db5-945bcd82d58a" />
<img width="559" height="711" alt="Screenshot 2026-05-12 at 11 45 06 AM" src="https://github.com/user-attachments/assets/f6a7cc02-73ce-4208-96e3-511f405ef80f" /> 

after: down to 831 KiB image delivery, render blocking requests down to 569 ms
<img width="490" height="711" alt="Screenshot 2026-05-12 at 11 42 19 AM" src="https://github.com/user-attachments/assets/a93e45f9-cb3a-45f2-a91b-c041f72705de" />
<img width="490" height="711" alt="Screenshot 2026-05-12 at 11 42 32 AM" src="https://github.com/user-attachments/assets/acbfddc1-ff63-49b5-8c6a-3c107f725f35" />



Note: It has hard to improve media-gallery images further since they are shown at 2 sizes but I only get 1 option to inject sizes data. 

**Time Report:**

This took about 2-3 hours to diagnose, revise and test

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   [X] I completed any required mobile breakpoint styling
-   [X] I completed any required hover state styling
-   [X] I included a working spec file
-   [X] I added notes above about how long it took to build this component
-   [X] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[LADI-3717]: https://uclalibrary.atlassian.net/browse/LADI-3717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ