### PR TITLE
fix: LADI-5191 Potential issue: duplicate main

### DIFF
--- a/components/ListOfItemsCollection.vue
+++ b/components/ListOfItemsCollection.vue
@@ -325,8 +325,7 @@ const pageClasses = computed(() => {
 </script>
 
 <template>
-  <main
-    id="main"
+  <div
     :class="pageClasses"
   >
     <div class="one-column">
@@ -421,7 +420,7 @@ const pageClasses = computed(() => {
         </template>
       </SectionWrapper>
     </div>
-  </main>
+  </div>
 </template>
 
 <style lang="scss" scoped>

--- a/pages/collections/la-rebellion/filmography/index.vue
+++ b/pages/collections/la-rebellion/filmography/index.vue
@@ -91,12 +91,15 @@ const breadcrumbOverrides = ref([
 </script>
 
 <template>
-  <div class="page-component-wrapper">
+  <main
+    id="main"
+    class="page-component-wrapper"
+  >
     <ListOfItemsCollection
       :page="page"
       :breadcrumbs="breadcrumbOverrides"
     />
-  </div>
+</main>
 </template>
 
 <style scoped>


### PR DESCRIPTION
Connected to [LADI-5191](https://jira.library.ucla.edu/browse/LADI-5191)

#### This PR deletes the extra main tag and main id that are added in conjuction with the ListOfItemsCollection.vue component.

[Do page sections with the same name serve the same purpose?](https://my2.siteimprove.com/Accessibility/1185691/NextGen/Issue/1?ruleId=55&pageSegments=&issueKind=2&exceptTags=1,2&conformance=&siteTargetIssueKinds=1,2&wcagVersion=21&siteTarget.wcagVersion=21&siteTarget.conformanceLevels=0,1,3,4&siteTarget.issueKinds=1,2) (4  occurrences out of 401)

1. BEFORE https://cinema.ucla.edu/collections/u-s-steel-hour
    AFTER https://deploy-preview-348--test-ftva.netlify.app/collections/u-s-steel-hour
2. BEFORE https://cinema.ucla.edu/collections/ktla-news-project/collections/ucla-ktla-news-project
    AFTER https://deploy-preview-348--test-ftva.netlify.app/collections/ktla-news-project
3. BEFORE https://cinema.ucla.edu/collections/the-goldbergs-on-the-radio
    AFTER https://deploy-preview-348--test-ftva.netlify.app/collections/the-goldbergs-on-the-radio
4. BEFORE https://cinema.ucla.edu/collections/ktla-news-project-tom-bradley-mayor-of-los-angeles
    AFTER https://deploy-preview-348--test-ftva.netlify.app/collections/ktla-news-project-tom-bradley-mayor-of-los-angeles

---

### `ListOfItemsCollection.vue`
I previous thought that there was an issue when the VueSkipTo plugin was added but the issue was actually with the `ListOfItemsCollection.vue` component.  

#### 1. `pages/collections/la-rebellion/filmography`
`ListOfItemsCollection.vue` is used in `pages/collections/la-rebellion/filmography`   
I updated  the `pages/collections/la-rebellion/filmography` page to use `<main id="main" class="page-component-wrapper">` instead of `<div class="page-component-wrapper">`

This page did not have a duplicate `<main id="main">` because the `ListOfItemsCollection.vue` component had a `<main id="main">` but the `pages/collections/la-rebellion/filmography` only used `<div class="page-component-wrapper">`   
It would have had no `<main id="main">` once the `ListOfItemsCollection.vue`  component was updated to use the `<div>`

#### 2. `pages/collections/[slug.vue]`
The `pages/collections/[slug.vue]` either uses the component  ListOfItemsCollection or BasicCollection

The `collections/[slug.vue]` has the `<main>` tag with the `id="main"`.   
When the ListOfItemsCollection.vue was pulled in it was adding another `<main>`  tag with the `id="main".`   
I removed that.

`pages/collections/[slug.vue]`
```
// Compute layout
const pageType = computed(() => {
  const collectionpagetype = _get(data.value, 'ftvaCollection.ftvaCollectionLayoutType', 'basic')
  if (collectionpagetype === 'listOfItems') {
    return ListOfItemsCollection
  } else {
    return BasicCollection // default to basic
  }
})
</script>

<template>
  <main
    id="main"
    class="page-component-wrapper"
  >
    <!-- static div wrapper element is necessary, dynamic component :is element will cause routing issues -->
    <!-- pass page as attrs so ElasticSearch powered pages don't have to fetch craftCMS page data again -->
    <component
      :is="pageType"
      :page="page"
    />
  </main>
</template>
```

previously `components/ListOfItemsCollection.vue`
```
<template>
  <main
    id="main"
    :class="pageClasses"
  >
  ...
  </main>
```

[LADI-5191]: https://uclalibrary.atlassian.net/browse/LADI-5191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ