### PR TITLE
fix: LADI-5192 FTVA Potential issue: Duplicate footers

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -74,12 +74,12 @@ useHead({
 
       <NuxtPage />
 
-      <footer data-test="footer">
-        <footer-main />
-      </footer>
+      <footer-main data-test="footer"/>
+
     </div>
   </div>
 </template>
+
 <style lang="scss" scoped>
 .layout-default {
   min-height: 100vh;


### PR DESCRIPTION
Connected to [LADI-5192](https://jira.library.ucla.edu/browse/LADI-5192)

BEFORE
https://cinema.ucla.edu/instructional-media-lab
<img width="1162" height="465" alt="Screenshot 2026-05-27 at 12 40 38 PM" src="https://github.com/user-attachments/assets/e78ebe5c-dabb-4d03-8a41-9e04dbfa5aeb" />

AFTER
https://deploy-preview-350--test-ftva.netlify.app/instructional-media-lab
<img width="1160" height="471" alt="Screenshot 2026-05-27 at 12 41 09 PM" src="https://github.com/user-attachments/assets/2c43b4f8-c486-498b-9276-f0ba94096fb5" />

---

#### Potential issue:  Do page sections with the same name serve the same purpose?  
400+ pages are affected

```js
<footer data-test="footer" data-v-5a1f35b5>
  <footer class="footer-main ftva" data-v-7e173785 data-v-5a1f35b5>  </footer>
</footer>
```

Previously the footer html tag was wrapping the footer-main component creating two footer tags.  
I moved the cypress `data-test="footer"` into the call for the component and deleted the extraneous footer tag.

```js
      <footer data-test="footer">
        <footer-main />
      </footer>
```

[LADI-5192]: https://uclalibrary.atlassian.net/browse/LADI-5192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ