### PR TITLE
feat: LADI-5193 Fallback to enable SkipToLink in Firefox

### DIFF
--- a/components/ARSCIMCSSection.vue
+++ b/components/ARSCIMCSSection.vue
@@ -121,6 +121,7 @@ useHead({
 <template>
   <main
     id="main"
+    tabindex="-1"
     :class="pageClasses"
   >
     <div class="one-column">

--- a/components/BasicCollection.vue
+++ b/components/BasicCollection.vue
@@ -159,7 +159,11 @@ const pageClasses = computed(() => {
 </script>
 
 <template>
-  <div :class="pageClasses">
+  <main
+    id="main"
+    tabindex="-1"
+    :class="pageClasses"
+  >
     <div class="one-column">
       <NavBreadcrumb
         data-test="breadcrumb"
@@ -275,7 +279,7 @@ const pageClasses = computed(() => {
         :grid-layout="false"
       />
     </SectionWrapper>
-  </div>
+  </main>
 </template>
 
 <style lang="scss" scoped>

--- a/components/CollectionTypeSection.vue
+++ b/components/CollectionTypeSection.vue
@@ -250,6 +250,7 @@ watch(data, (newVal, oldVal) => {
 <template>
   <main
     id="main"
+    tabindex="-1"
     :class="pageClasses"
   >
     <div class="one-column">

--- a/components/ListOfItemsCollection.vue
+++ b/components/ListOfItemsCollection.vue
@@ -327,6 +327,7 @@ const pageClasses = computed(() => {
 <template>
   <main
     id="main"
+    tabindex="-1"
     :class="pageClasses"
   >
     <div class="one-column">

--- a/components/ListOfItemsCollection.vue
+++ b/components/ListOfItemsCollection.vue
@@ -422,7 +422,7 @@ const pageClasses = computed(() => {
         </template>
       </SectionWrapper>
     </div>
-  </div>
+  </main>
 </template>
 
 <style lang="scss" scoped>

--- a/error.vue
+++ b/error.vue
@@ -30,6 +30,7 @@ useHead({
   <NuxtLayout :is-error="true">
     <main
       id="main"
+      tabindex="-1"
       class="page page-error"
     >
       <SectionWrapper

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -115,6 +115,7 @@ onMounted(() => {
 <template lang="html">
   <main
     id="main"
+    tabindex="-1"
     :class="pageClasses"
   >
     <div class="one-column">

--- a/pages/billy-wilder-theater.vue
+++ b/pages/billy-wilder-theater.vue
@@ -130,6 +130,7 @@ const pageClasses = computed(() => {
 <template>
   <main
     id="main"
+    tabindex="-1"
     :class="pageClasses"
   >
     <div class="one-column">

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -141,6 +141,7 @@ const parseBlocks = computed(() => {
 <template>
   <main
     id="main"
+    tabindex="-1"
     class="page page-detail page-detail--paleblue page-article-detail"
   >
     <div class="one-column">

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -193,7 +193,11 @@ const pageClasses = computed(() => {
 </script>
 
 <template>
-  <main id="main" :class="pageClasses">
+  <main
+    id="main"
+    tabindex="-1"
+    :class="pageClasses"
+  >
     <SectionWrapper
       ref="scrollElem"
       :level="1"

--- a/pages/collections/[collectionSlug]/[slug].vue
+++ b/pages/collections/[collectionSlug]/[slug].vue
@@ -231,6 +231,7 @@ const pageClasses = computed(() => {
 <template>
   <main
     id="main"
+    tabindex="-1"
     :class="pageClasses"
   >
     <div class="collection-item-header">

--- a/pages/collections/[slug].vue
+++ b/pages/collections/[slug].vue
@@ -52,6 +52,7 @@ const pageType = computed(() => {
 <template>
   <main
     id="main"
+    tabindex="-1"
     class="page-component-wrapper"
   >
     <!-- static div wrapper element is necessary, dynamic component :is element will cause routing issues -->

--- a/pages/collections/index.vue
+++ b/pages/collections/index.vue
@@ -160,6 +160,7 @@ const pageClasses = computed(() => {
 <template>
   <main
     id="main"
+    tabindex="-1"
     :class="pageClasses"
   >
     <div class="one-column">

--- a/pages/collections/la-rebellion/filmmakers/[slug].vue
+++ b/pages/collections/la-rebellion/filmmakers/[slug].vue
@@ -121,6 +121,7 @@ const pageClasses = computed(() => {
 <template>
   <main
     id="main"
+    tabindex="-1"
     :class="pageClasses"
   >
     <div class="one-column">

--- a/pages/collections/la-rebellion/filmmakers/index.vue
+++ b/pages/collections/la-rebellion/filmmakers/index.vue
@@ -213,6 +213,7 @@ const breadcrumbOverrides = ref([
 <template>
   <main
     id="main"
+    tabindex="-1"
     :class="pageClasses"
   >
     <div class="one-column">

--- a/pages/collections/la-rebellion/index.vue
+++ b/pages/collections/la-rebellion/index.vue
@@ -132,6 +132,7 @@ const pageClasses = computed(() => {
 <template>
   <main
     id="main"
+    tabindex="-1"
     :class="pageClasses"
   >
     <div class="one-column">

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -170,6 +170,7 @@ const pageClasses = computed(() => {
 <template>
   <main
     id="main"
+    tabindex="-1"
     :class="pageClasses"
   >
     <div class="one-column">

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -510,6 +510,7 @@ const pageClasses = computed(() => {
 <template>
   <main
     id="main"
+    tabindex="-1"
     :class="pageClasses"
   >
     <div class="full-width">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -239,6 +239,7 @@ const pageClasses = computed(() => {
 <template>
   <main
     id="main"
+    tabindex="-1"
     :class="pageClasses"
   >
     <h1 class="screen-reader-text">

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -431,6 +431,7 @@ const pageClasses = computed(() => {
 <template>
   <main
     id="main"
+    tabindex="-1"
     :class="pageClasses"
   >
     <SectionWrapper
@@ -519,7 +520,7 @@ const pageClasses = computed(() => {
           v-show="!noResultsFound
             &&
             totalResults > 0
-          "
+            "
           ref="el"
           class="results"
         >

--- a/pages/series/[slug].vue
+++ b/pages/series/[slug].vue
@@ -324,6 +324,7 @@ useHead({
 <template>
   <main
     id="main"
+    tabindex="-1"
     class="page page-detail page-detail--paleblue page-event-series-detail"
   >
     <div class="one-column">

--- a/pages/series/index.vue
+++ b/pages/series/index.vue
@@ -173,7 +173,11 @@ const pageClasses = computed(() => {
 </script>
 
 <template>
-  <main id="main" :class="pageClasses">
+  <main
+    id="main"
+    tabindex="-1"
+    :class="pageClasses"
+  >
     <div class="full-width">
       <SectionWrapper
         id="series-section-title"

--- a/pages/touring-series/[slug].vue
+++ b/pages/touring-series/[slug].vue
@@ -144,6 +144,7 @@ useHead({
 <template>
   <main
     id="main"
+    tabindex="-1"
     class="page page-detail page-detail--paleblue page-touring-series-detail"
   >
     <div class="one-column">

--- a/pages/touring-series/index.vue
+++ b/pages/touring-series/index.vue
@@ -191,7 +191,11 @@ const pageClasses = computed(() => {
 </script>
 
 <template>
-  <main id="main" :class="pageClasses">
+  <main
+    id="main"
+    tabindex="-1"
+    :class="pageClasses"
+  >
     <div class="full-width">
       <SectionWrapper
         id="series-section-title"

--- a/plugins/add-vue-skip-to.js
+++ b/plugins/add-vue-skip-to.js
@@ -1,9 +1,36 @@
 import VueSkipTo from '@vue-a11y/skip-to'
 import '@vue-a11y/skip-to/dist/style.css'
 
-export default defineNuxtPlugin((nuxtApp) => { //
-  // Doing something with nuxtApp
-  // console.log("print external component: " + VueSkipTo)
+export default defineNuxtPlugin((nuxtApp) => {
+  // Make plugin available throughout app
   nuxtApp.vueApp.use(VueSkipTo)
-  // console.log("print vue skip to component: "+VueSkipTo)
+
+  // Fallback to ensure SkipToLink functionality works in browsers--particularly Firefox (LADI-5193)
+
+  if (process.client) { // Run only on client-side
+    document.addEventListener('click', (e) => {
+      // Identify the skip-to-link element
+      const link = e.target.closest('.vue-skip-to__link')
+
+      if (!link) return
+
+      // Find the target element (main content) via the href attr
+      const targetId = link.getAttribute('href')
+      const el = document.querySelector(targetId)
+
+      if (!el) return
+
+      requestAnimationFrame(() => {
+        // 1. Set tabindex and apply focus to the target
+        el.setAttribute('tabindex', '-1')
+        el.focus()
+
+        // 2. Scroll to main content
+        window.scrollTo({
+          top: el.getBoundingClientRect().top + window.scrollY,
+          behavior: 'auto'
+        })
+      })
+    })
+  }
 })


### PR DESCRIPTION
Connected to [LADI-5193](https://jira.library.ucla.edu/browse/LADI-5193)

**Pages updated:** All pages

**Notes:**
- Added `tabindex` to `main` element tag on all pages to make it focusable
  - Without this pattern, there's a possibility users won't be able to skip to main content in some browsers
- Updated SkipToLink plugin with JS fallback to ensure skipping to the main content works if adding `tabindex` in the markup doesn't always work (_this is the case in Firefox_)

**Checklist:**

-   [x] I added github label for semantic versioning
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~
-   [x] I have requested a PR review from the Dev team


[LADI-5193]: https://uclalibrary.atlassian.net/browse/LADI-5193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ