### PR TITLE
fix: LADI-5228, LADI-5231 fix axe-core violations and re-enable tests

### DIFF
--- a/cypress/e2e/exploreCollectionsPage.cy.js
+++ b/cypress/e2e/exploreCollectionsPage.cy.js
@@ -30,7 +30,6 @@ if (isChromatic) {
 } else {
   describe('Explore Collections Page', () => {
     runExploreCollectionsTests({ withSnapshot: false })
-    // TODO: reenable when LADI-5228 is fixed
-    a11yIt.skip('/collections')
+    a11yIt('/collections')
   })
 }

--- a/cypress/e2e/homepage.cy.js
+++ b/cypress/e2e/homepage.cy.js
@@ -49,8 +49,7 @@ if (isChromatic) {
   })
 } else {
   describe('Website Homepage', () => {
-    runHomepageTests({ withSnapshot: false })
-    // TODO: reenable when LADI-5226, LADI-5231 is fixed
+    runHomepageTests({ withSnapshot: false })x
     // check the entire page for accessibility violations, including the header and footer
     a11yIt('/', { selector: null })
   })

--- a/cypress/e2e/homepage.cy.js
+++ b/cypress/e2e/homepage.cy.js
@@ -52,6 +52,6 @@ if (isChromatic) {
     runHomepageTests({ withSnapshot: false })
     // TODO: reenable when LADI-5226, LADI-5231 is fixed
     // check the entire page for accessibility violations, including the header and footer
-    a11yIt.skip('/', { selector: null })
+    a11yIt('/', { selector: null })
   })
 }

--- a/cypress/e2e/homepage.cy.js
+++ b/cypress/e2e/homepage.cy.js
@@ -49,7 +49,7 @@ if (isChromatic) {
   })
 } else {
   describe('Website Homepage', () => {
-    runHomepageTests({ withSnapshot: false })x
+    runHomepageTests({ withSnapshot: false })
     // check the entire page for accessibility violations, including the header and footer
     a11yIt('/', { selector: null })
   })

--- a/pages/collections/index.vue
+++ b/pages/collections/index.vue
@@ -279,6 +279,7 @@ const pageClasses = computed(() => {
       data-test="hearst-collection"
     >
       <BlockCardWithImage
+        :tag="'div'"
         :image="parsedHearstCollectionImage"
         :to="page.hearstUri"
         :card-is-link="true"


### PR DESCRIPTION
#### Connected to [LADI-5228](https://jira.library.ucla.edu/browse/LADI-5228) [LADI-5231](https://jira.library.ucla.edu/browse/LADI-5231)

#### Deployed on https://deploy-preview-357--test-ftva.netlify.app

---

### Notes

Since the changes needed for both of these tickets were small I opted to batch them together. 

LADI-5228

- [X] I used the 'tag' prop to get the component to render with a div instead of an li, since this component is outside of a list element in this case
- [X] I re-enabled the tests and observed that they passed

LADI-5231

- [X] Missing alt text in an image in the page was causing a violation, I added the data on test-craft
- [X] I re-enabled the tests and observed that they passed

---

## Checklist

### Author
- [X] Browsers
    - [X] Review PR in Chrome, Firefox, Safari, Edge
    - [X] Review PR in desktop view, tablet view, mobile view
- [X] A11Y
    - [X] Zoom the site to 200%
    - [X] Check for keyboard traps
- [X] Design & Code
    - [X] Check that it looks like the design(s) _(if applicable)_
    - [X] Include a working / updated spec file _(if applicable)_
    - ~~[ ] Review the Chromatic~~

### UX Review
- [ ] UX has reviewed and approved

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the deploy preview
  - [ ] Review the code


[LADI-5228]: https://uclalibrary.atlassian.net/browse/LADI-5228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LADI-5231]: https://uclalibrary.atlassian.net/browse/LADI-5231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ