### PR TITLE
feat: LADI-5229 re-enable series slug test, LADI-5230

### DIFF
--- a/cypress/e2e/eventSeriesDetailPage.cy.js
+++ b/cypress/e2e/eventSeriesDetailPage.cy.js
@@ -23,7 +23,6 @@ if (isChromatic) {
 } else {
   describe('Event Series Detail Page', () => {
     runEventSeriesDetailTests({ withSnapshot: false })
-    // TODO: reenable when LADI-5229 is fixed
     a11yIt.skip('/series/step-up-series')
   })
 }

--- a/cypress/e2e/eventSeriesDetailPage.cy.js
+++ b/cypress/e2e/eventSeriesDetailPage.cy.js
@@ -23,6 +23,6 @@ if (isChromatic) {
 } else {
   describe('Event Series Detail Page', () => {
     runEventSeriesDetailTests({ withSnapshot: false })
-    a11yIt.skip('/series/step-up-series')
+    a11yIt('/series/step-up-series')
   })
 }

--- a/cypress/e2e/touringSeriesDetailPage.cy.js
+++ b/cypress/e2e/touringSeriesDetailPage.cy.js
@@ -23,7 +23,6 @@ if (isChromatic) {
 } else {
   describe('Touring Series Detail Page', () => {
     runTouringSeriesDetailTests({ withSnapshot: false })
-    // TODO: reenable when LADI-5230 is fixed
-    a11yIt.skip('/touring-series/through-indian-eyes-native-american-cinema')
+    a11yIt('/touring-series/through-indian-eyes-native-american-cinema')
   })
 }


### PR DESCRIPTION
#### Connected to [LADI-5229](https://jira.library.ucla.edu/browse/LADI-5229),  [LADI-5230](https://jira.library.ucla.edu/browse/LADI-5230)

#### Deployed on https://deploy-preview-358--test-ftva.netlify.app

---

### Notes

Both these pages had axe-core errors for missing alt text. I added the missing alt text in craft to several images, then I removed the 'skip' from the tests. 

---

## Checklist

### Author
- [X] Browsers
    - [X] Review PR in Chrome, Firefox, Safari, Edge
    - [X] Review PR in desktop view, tablet view, mobile view
- [X] A11Y
    - [X] Zoom the site to 200%
    - [X] Check for keyboard traps
- [X] Design & Code
    - [X] Check that it looks like the design(s) _(if applicable)_
    - [X] Include a working / updated spec file _(if applicable)_
    - ~~[ ] Review the Chromatic~~

### UX Review
- ~~[ ] UX has reviewed and approved~~

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the deploy preview
  - [ ] Review the code


[LADI-5229]: https://uclalibrary.atlassian.net/browse/LADI-5229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LADI-5230]: https://uclalibrary.atlassian.net/browse/LADI-5230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ