### PR TITLE
fix: LADI-5227 Fix blog index's featured article wrapper a11y issue

### DIFF
--- a/cypress/e2e/blogListPage.cy.js
+++ b/cypress/e2e/blogListPage.cy.js
@@ -47,7 +47,6 @@ else {
   describe('Blog Listing Page', () => {
     runBlogListingTests({ withSnapshot: false })
     runMobileBehaviorTest()
-    // TODO: reenable when LADI-5227 is fixed
-    a11yIt.skip('/blog')
+    a11yIt('/blog')
   })
 }

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -231,7 +231,7 @@ const pageClasses = computed(() => {
         {{ isMobile ? 'Featured Blog' : 'Featured Blogs' }}
       </SectionHeader>
 
-      <div class="featured-articles-wrapper">
+      <ul class="featured-articles-wrapper">
         <BlockCardWithImage
           v-for="article, index in parsedFeaturedArticles"
           :key="article.title"
@@ -254,7 +254,7 @@ const pageClasses = computed(() => {
             <RichText :rich-text-content="article.text" />
           </template>
         </BlockCardWithImage>
-      </div>
+      </ul>
     </SectionWrapper>
 
     <SectionWrapper


### PR DESCRIPTION
#### Connected to [LADI-5227](https://jira.library.ucla.edu/browse/LADI-5227)

#### Deployed: https://deploy-preview-359--test-ftva.netlify.app/blog/

### Notes
- Changed `div` tag to `ul`tag in `featured-articles-wrapper` element
- Re-enable A11Y test

---

## Checklist

### Author
- [x] Browsers
    - [x] Review PR in Chrome, Firefox, Safari, Edge
    - [x] Review PR in desktop view, tablet view, mobile view
- ~~[ ] A11Y~~
    - ~~[ ] Zoom the site to 200%~~
    - ~~[ ] Check for keyboard traps~~
- ~~[ ] Design & Code~~
    - ~~[ ] Check that it looks like the design(s) _(if applicable)_~~
    - ~~[ ] Include a working / updated spec file _(if applicable)_~~
    - ~~[ ] Review the Chromatic~~

### UX Review
- ~~[ ] UX has reviewed and approved~~

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the deploy preview
  - [ ] Review the code


[LADI-5227]: https://uclalibrary.atlassian.net/browse/LADI-5227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ