### PR TITLE
fix: LADI-3658 Change browse results text to 'item(s)'

### DIFF
--- a/app/components/CollectionTypeSection.vue
+++ b/app/components/CollectionTypeSection.vue
@@ -301,11 +301,10 @@ watch(data, (newVal, oldVal) => {
           ref="resultsSection"
           class="browse-results"
         >
-          <!-- 0 results, 1 result, 2 results, etc. -->
           <h2>
-            {{ hits }} {{ hits === 1 ? `result` :
-              `results`
-            }} shown
+            {{ hits }} {{ hits === 1 ? `item` :
+              `items`
+            }}
           </h2>
         </div>
 

--- a/app/components/ListOfItemsCollection.vue
+++ b/app/components/ListOfItemsCollection.vue
@@ -182,7 +182,7 @@ watch(() => route.query, async (newVal, oldVal) => {
 
 // Format # of results of BlockTag display
 const totalResultsDisplay = computed(() => {
-  return totalResults.value + ' Video Clip' + (totalResults.value > 1 ? 's' : '')
+  return totalResults.value + ' item' + (totalResults.value === 1 ? '' : 's')
 })
 
 // SORT SETUP - uses static data


### PR DESCRIPTION
#### Connected to [LADI-3658](https://jira.library.ucla.edu/browse/LADI-3658)

#### Deployed Preview:
- https://deploy-preview-361--test-ftva.netlify.app/collections/motion-picture/
- https://deploy-preview-361--test-ftva.netlify.app/collections/television/
- https://deploy-preview-361--test-ftva.netlify.app/collections/watch-listen-online/
- https://deploy-preview-361--test-ftva.netlify.app/collections/la-rebellion/filmography/
- https://deploy-preview-361--test-ftva.netlify.app/collections/ucla-ktla-news-project/

### Notes

- Updated text in browse results code to say `item(s)` instead of `result(s)` and `Video Clip(s)`

---

## Checklist

### Author
- [x] Browsers
    - [x] Review PR in Chrome, Firefox, Safari, Edge
    - [x] Review PR in desktop view, tablet view, mobile view
- ~~[ ] A11Y~~
    - ~~[ ] Zoom the site to 200%~~
    - ~~[ ] Check for keyboard traps~~
- ~~[ ] Design & Code~~
    - ~~[ ] Check that it looks like the design(s) _(if applicable)_~~
    - ~~[ ] Include a working / updated spec file _(if applicable)_~~
    - ~~[ ] Review the Chromatic~~

### UX Review
- [ ] UX has reviewed and approved

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the deploy preview
  - [ ] Review the code


[LADI-3658]: https://uclalibrary.atlassian.net/browse/LADI-3658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ