### PR TITLE
fix: LADI-3768 fix series page plan visit link

### DIFF
--- a/app/pages/series/[slug].vue
+++ b/app/pages/series/[slug].vue
@@ -425,7 +425,7 @@ useHead({
           <template #block-info-end>
             <ButtonLink
               label="Plan Your Visit"
-              to="/plan-your-visit"
+              to="/billy-wilder-theater"
               class="button"
               :is-secondary="true"
               icon-name="none"

--- a/public/_redirects
+++ b/public/_redirects
@@ -640,6 +640,7 @@
 /motion-picture-collection	/collections/motion-picture
 /our-history	/about-the-archive/our-history
 /placing-course-reserves	/instructional-media-collections-services/placing-course-reserves
+/plan-your-visit /billy-wilder-theater
 /programs/admission	/billy-wilder-theater
 /programs/tours	/touring-series
 /programs/ucla-festival-preservation	/ucla-festival-of-preservation


### PR DESCRIPTION
#### Connected to [LADI-3768](https://jira.library.ucla.edu/browse/LADI-3768)

#### Deployed Preview: 

- https://deploy-preview-362--test-ftva.netlify.app/series/
- Redirect: https://deploy-preview-362--test-ftva.netlify.app/plan-your-visit/

### Notes

- Updated `plan-your-visit` link on Series slug page to `billy-wilder-theater`
- Added redirect

---

## Checklist

### Author
- [x] Browsers
    - [x] Review PR in Chrome, Firefox, Safari, Edge
    - ~~[ ] Review PR in desktop view, tablet view, mobile view~~
- ~~[ ] A11Y~~
    - ~~[ ] Zoom the site to 200%~~
    - ~~[ ] Check for keyboard traps~~
- ~~[ ] Design & Code~~
    - ~~[ ] Check that it looks like the design(s) _(if applicable)_~~
    - ~~[ ] Include a working / updated spec file _(if applicable)_~~
    - ~~[ ] Review the Chromatic~~

### UX Review
- [ ] UX has reviewed and approved

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the deploy preview
  - [ ] Review the code


[LADI-3768]: https://uclalibrary.atlassian.net/browse/LADI-3768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ